### PR TITLE
implementation of explicit swap on containers

### DIFF
--- a/include/small_vectors/detail/uninitialized_constexpr.h
+++ b/include/small_vectors/detail/uninitialized_constexpr.h
@@ -316,7 +316,7 @@ inline constexpr void uninitialized_uneven_range_swap(
     std::swap(size1, size2);
     }
   std::swap_ranges(iter1, iter1 + size1, iter2);
-  uninitialized_relocate_if_noexcept_n(iter2 + size1, size2 - size1, iter1 + size1);
+  uninitialized_relocate_if_noexcept_n(iter2 + size1, size_type(size2 - size1), iter1 + size1);
   }
 
   }  // namespace small_vectors::inline v3_0::detail

--- a/include/small_vectors/small_vector.h
+++ b/include/small_vectors/small_vector.h
@@ -175,8 +175,7 @@ struct small_vector
 
   template<concepts::unsigned_arithmetic_integral arg_size_type>
   [[nodiscard]]
-  inline constexpr auto
-    operator[](arg_size_type index) const noexcept -> value_type const &
+  inline constexpr auto operator[](arg_size_type index) const noexcept -> value_type const &
     {
     assert(index < size());
     return data()[index];
@@ -184,8 +183,7 @@ struct small_vector
 
   template<concepts::unsigned_arithmetic_integral arg_size_type>
   [[nodiscard]]
-  inline constexpr auto
-    operator[](arg_size_type index) noexcept -> value_type &
+  inline constexpr auto operator[](arg_size_type index) noexcept -> value_type &
     {
     assert(index < size());
     return data()[index];
@@ -329,6 +327,8 @@ struct small_vector
     }
 
   inline constexpr auto shrink_to_fit() -> vector_outcome_e { return detail::shrink_to_fit(*this); }
+
+  inline constexpr void swap(small_vector & b) noexcept { storage_.swap(b.storage_); }
   };
 
 template<typename V, std::unsigned_integral S, uint64_t N>
@@ -347,9 +347,7 @@ namespace concepts
   concept same_as_small_vector = requires {
     typename small_vector_type::value_type;
     typename small_vector_type::size_type;
-      {
-      small_vector_type::buffered_capacity()
-      } noexcept -> std::same_as<typename small_vector_type::size_type>;
+      { small_vector_type::buffered_capacity() } noexcept -> std::same_as<typename small_vector_type::size_type>;
       requires concepts::unsigned_arithmetic_integral<typename small_vector_type::size_type>;
     requires std::same_as<
       std::remove_const_t<small_vector_type>,

--- a/include/small_vectors/static_vector.h
+++ b/include/small_vectors/static_vector.h
@@ -54,8 +54,7 @@ struct static_vector
 #if !defined(WIN32)
   [[no_unique_address]]
 #endif
-  detail::static_vector_storage<value_type, capacity_>
-    storage_;
+  detail::static_vector_storage<value_type, capacity_> storage_;
 
   [[nodiscard]]
   static inline constexpr auto capacity() noexcept -> size_type
@@ -174,16 +173,15 @@ struct static_vector
   inline constexpr auto crend() const noexcept -> const_reverse_iterator { return const_reverse_iterator{begin()}; }
 
   [[nodiscard]]
-  inline constexpr auto
-    operator[](concepts::unsigned_arithmetic_integral auto index) const noexcept -> value_type const &
+  inline constexpr auto operator[](concepts::unsigned_arithmetic_integral auto index
+  ) const noexcept -> value_type const &
     {
     assert(index < storage_.size_);
     return data()[index];
     }
 
   [[nodiscard]]
-  inline constexpr auto
-    operator[](concepts::unsigned_arithmetic_integral auto index) noexcept -> value_type &
+  inline constexpr auto operator[](concepts::unsigned_arithmetic_integral auto index) noexcept -> value_type &
     {
     assert(index < storage_.size_);
     return data()[index];
@@ -247,8 +245,8 @@ struct static_vector
       return detail::emplace_unchecked(*this, itpos, std::forward<Args>(args)...);
     }
 
-  inline constexpr auto resize(size_type new_size) noexcept(noexcept(detail::resize(*this, new_size)))
-    -> vector_outcome_e
+  inline constexpr auto resize(size_type new_size) noexcept(noexcept(detail::resize(*this, new_size))
+  ) -> vector_outcome_e
     {
     return detail::resize(*this, new_size);
     }
@@ -259,6 +257,8 @@ struct static_vector
     }
 
   inline constexpr void set_size_priv_(size_type pos_ix) noexcept { storage_.size_ = pos_ix; }
+
+  inline constexpr void swap(static_vector & b) noexcept { storage_.swap(b.storage_); }
   };
 
 namespace concepts
@@ -359,8 +359,9 @@ inline constexpr auto & back(static_vector_type & vec) noexcept
   }
 
 template<typename V, uint64_t N>
-inline constexpr auto erase_at_end(static_vector<V, N> & vec, typename static_vector<V, N>::const_iterator pos) noexcept
-  -> typename static_vector<V, N>::iterator
+inline constexpr auto
+  erase_at_end(static_vector<V, N> & vec, typename static_vector<V, N>::const_iterator pos) noexcept ->
+  typename static_vector<V, N>::iterator
   {
   return vec.erase_at_end(pos);
   }
@@ -498,4 +499,4 @@ inline constexpr vector_outcome_e split_by_half(
   else
     return vector_outcome_e::out_of_storage;
   }
-  }  // namespace coll
+  }  // namespace small_vectors::inline v3_0

--- a/unit_tests/small_vector_ut.cc
+++ b/unit_tests/small_vector_ut.cc
@@ -2324,11 +2324,11 @@ int main()
       constexpr_test(size(vec) == 4) | constexpr_test(equal(vec, expected1));
       constexpr_test(size(vec2) == 2) | constexpr_test(equal(vec2, expected2));
 
-      std::swap(vec, vec2);
+      vec.swap(vec2);
       constexpr_test(size(vec2) == 4) | constexpr_test(equal(vec2, expected1));
       constexpr_test(size(vec) == 2) | constexpr_test(equal(vec, expected2));
 
-      std::swap(vec, vec2);
+      vec.swap(vec2);
       constexpr_test(size(vec) == 4) | constexpr_test(equal(vec, expected1));
       constexpr_test(size(vec2) == 2) | constexpr_test(equal(vec2, expected2));
       return {};
@@ -2358,7 +2358,7 @@ int main()
         vec.emplace_back(S{1});
         vec.emplace_back(S{2});
 
-        std::swap(vec, vec2);
+        vec.swap(vec2);
         expect(size(vec) == 0);
         expect(size(vec2) == 2);
         }

--- a/unit_tests/static_vector_ut.cc
+++ b/unit_tests/static_vector_ut.cc
@@ -683,7 +683,7 @@ int main()
       constexpr_test(size(vec) == 4) | constexpr_test(equal(vec, expected1));
       constexpr_test(size(vec2) == 2) | constexpr_test(equal(vec2, expected2));
 
-      std::swap(vec, vec2);
+      vec.swap(vec2);
       constexpr_test(size(vec2) == 4) | constexpr_test(equal(vec2, expected1));
       constexpr_test(size(vec) == 2) | constexpr_test(equal(vec, expected2));
       return {};


### PR DESCRIPTION
Following advice from @Quuxplusone.
up to now containers didn't provide swap member function, so by using std::swap, swap was done swap by trivial std::swap implementation by moving containers with tmp value

