### PR TITLE
Handle user buffer overflows in operators[]

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -132,7 +132,7 @@ BinPackArguments: false
 BinPackParameters: false
 AlignAfterOpenBracket: BlockIndent
 WhitespaceSensitiveMacros:
-  - PRAGMA_CLANG_WARNING_OFF
-  - PRAGMA_CLANG_WARNING_PUSH_OFF
-  - PRAGMA_GCC_WARNING_PUSH_OFF
-  - PRAGMA_GCC_WARNING_OFF
+  - small_vectors_clang_unsafe_buffer_usage
+  - small_vectors_clang_unsafe_buffer_usage_begin
+  - small_vectors_clang_unsafe_buffer_usage_end
+

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -23,20 +23,20 @@ jobs:
       run: |
         wget https://apt.llvm.org/llvm.sh
         chmod +x llvm.sh
-        sudo ./llvm.sh 18
+        sudo ./llvm.sh 19
         
     - name: Install dependencies
       run: |
            sudo apt-get update
-           sudo apt-get install -y gcc-14 g++-14 cmake ninja-build clang-18 libfmt-dev libc++-18-dev libc++abi-18-dev
-           sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-18 100
-           sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-18 100
+           sudo apt-get install -y gcc-14 g++-14 cmake ninja-build clang-19 libfmt-dev libc++-19-dev libc++abi-19-dev
+           sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-19 100
+           sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-19 100
 
-    - name: tests clang-18-release
-      run: cmake --workflow --preset="clang-18-release"
+    - name: tests clang-19-release
+      run: cmake --workflow --preset="clang-19-release"
 
-    - name: tests clang-18-libc++release
-      run: cmake --workflow --preset="clang-18-libc++release"
+    - name: tests clang-19-libc++release
+      run: cmake --workflow --preset="clang-19-libc++release"
       
     - name: tests gcc-14-release
       run: cmake --workflow --preset="gcc-14-release"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,8 +28,7 @@ set(CMAKE_MODULE_PATH
   )
   
 option(SMALL_VECTORS_ENABLE_CPM_PACKAGING "cmake packaging by cpm" ON)
-option(SMALL_VECTORS_EXPECTED_VTABLE_INSTANTATION "builds static library with vtable of bad_expected_access" ON)
-add_feature_info("SMALL_VECTORS_EXPECTED_VTABLE_INSTANTATION" SMALL_VECTORS_EXPECTED_VTABLE_INSTANTATION "builds static library with vtable of bad_expected_access")
+set(SMALL_VECTORS_EXPECTED_VTABLE_INSTANTATION ON)
 
 if(SMALL_VECTORS_ENABLE_CPM_PACKAGING)
   include(cmake/get_cpm.cmake)
@@ -66,8 +65,12 @@ endif()
 message(STATUS "CMake install directory: " ${CMAKE_INSTALL_INCLUDEDIR})
 
 if(SMALL_VECTORS_EXPECTED_VTABLE_INSTANTATION)
-  add_library(small_vectors STATIC)
-  target_sources(small_vectors PRIVATE source/expected.cc)
+  add_library(small_vectors)
+  target_sources(small_vectors PRIVATE
+   source/expected.cc
+   source/safe_buffers.cc
+   )
+  
   target_compile_definitions( small_vectors PUBLIC SMALL_VECTORS_EXPECTED_VTABLE_INSTANTATION=1)
 else()
   add_library(small_vectors INTERFACE)
@@ -116,7 +119,7 @@ if( PROJECT_IS_TOP_LEVEL )
         )
       check_cxx_compiler_flag(-Wunsafe-buffer-usage WUNSAFE_BUFFER_USAGE)
       if(WUNSAFE_BUFFER_USAGE)
-        list(APPEND SMALL_VECTORS_COMPILE_OPTIONS -Wno-unsafe-buffer-usage)
+        list(APPEND SMALL_VECTORS_COMPILE_OPTIONS -Wunsafe-buffer-usage)
       endif()
       check_cxx_compiler_flag(-Wswitch-default WNO_SWITCH_DEFAULT)
       if(WNO_SWITCH_DEFAULT)

--- a/include/small_vectors/algo/bound_leaning_lower_bound.h
+++ b/include/small_vectors/algo/bound_leaning_lower_bound.h
@@ -5,7 +5,7 @@
 #include <iterator>
 
 /// \brief Burrows–Wheeler transform
-namespace small_vectors::inline v3_0::algo::lower_bound
+namespace small_vectors::inline v3_2::algo::lower_bound
   {
 
 // Idea from Andrei Alexandrescu on improved lower bound
@@ -71,4 +71,4 @@ struct bound_leaning_lower_bound_fn
   };
 
 inline constexpr bound_leaning_lower_bound_fn bound_leaning{};
-  }  // namespace small_vectors::inline v3_0::algo::lower_bound
+  }  // namespace small_vectors::inline v3_2::algo::lower_bound

--- a/include/small_vectors/algo/bwt.h
+++ b/include/small_vectors/algo/bwt.h
@@ -8,7 +8,7 @@
 #include <boost/container/flat_map.hpp>
 
 /// \brief Burrows–Wheeler transform
-namespace small_vectors::inline v3_0::algo::bwt
+namespace small_vectors::inline v3_2::algo::bwt
   {
 namespace concepts
   {
@@ -175,4 +175,4 @@ struct decode_t
 
 template<char end_char>
 inline constexpr decode_t<end_char> decode;
-  }  // namespace small_vectors::inline v3_0::algo::bwt
+  }  // namespace small_vectors::inline v3_2::algo::bwt

--- a/include/small_vectors/algo/bwt.h
+++ b/include/small_vectors/algo/bwt.h
@@ -49,8 +49,11 @@ struct encode_t
           auto it{data};
           it = ranges::copy(beg, end, it).out;
           *it = char_type(end_marker);
-          ++it;
-          it = ranges::copy(beg, end, it).out;
+          small_vectors_clang_unsafe_buffer_usage_begin  //
+            ++ it;
+          small_vectors_clang_unsafe_buffer_usage_end  //
+            it
+            = ranges::copy(beg, end, it).out;
           *it = char_type(end_marker);
           return sz + sz;
         }
@@ -116,8 +119,10 @@ struct decode_t
     using index_list = small_vector<uint32_t, uint32_t>;
     if(beg != end)
       {
-      std::span const btw_arr{beg, end};
-      auto it_x{ranges::find(btw_arr, char_type(end_marker))};
+      small_vectors_clang_unsafe_buffer_usage_begin  //
+        std::span const btw_arr{beg, end};
+      small_vectors_clang_unsafe_buffer_usage_end  //
+        auto it_x{ranges::find(btw_arr, char_type(end_marker))};
       if(it_x != ranges::end(btw_arr))
         {
         size_type const sz{size_type(btw_arr.size())};

--- a/include/small_vectors/basic_fixed_string.h
+++ b/include/small_vectors/basic_fixed_string.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <small_vectors/detail/safe_buffers.h>
 #include <small_vectors/concepts/concepts.h>
 #include <small_vectors/concepts/integral_or_byte.h>
 #include <small_vectors/detail/adapter_iterator.h>
@@ -53,39 +54,70 @@ struct basic_fixed_string
   [[nodiscard]]
   constexpr auto end() const noexcept -> const_iterator
     {
-    return const_iterator{&data_[N]};
+    small_vectors_clang_unsafe_buffer_usage_begin  //
+      return const_iterator{&data_[N]};
+    small_vectors_clang_unsafe_buffer_usage_end  //
     }
 
   [[nodiscard]]
   constexpr auto end() noexcept -> iterator
     {
-    return iterator{&data_[N]};
+    small_vectors_clang_unsafe_buffer_usage_begin  //
+      return iterator{&data_[N]};
+    small_vectors_clang_unsafe_buffer_usage_end  //
     }
 
   [[nodiscard]]
-  inline constexpr auto
-    operator[](concepts::unsigned_arithmetic_integral auto index) const noexcept -> char_type const &
+  inline constexpr auto operator[](concepts::unsigned_arithmetic_integral auto index) const noexcept
+    -> char_type const &
     {
+    small_vectors_clang_unsafe_buffer_usage_begin  //
+      if constexpr(detail::check_valid_element_access)
+      {
+      if(N <= index) [[unlikely]]
+        detail::report_invalid_element_access("out of bounds element access ", N, index);
+      }
     return data_[index];
+    small_vectors_clang_unsafe_buffer_usage_end  //
     }
 
   [[nodiscard]]
-  inline constexpr auto
-    operator[](concepts::unsigned_arithmetic_integral auto index) noexcept -> char_type &
+  inline constexpr auto operator[](concepts::unsigned_arithmetic_integral auto index) noexcept -> char_type &
     {
+    small_vectors_clang_unsafe_buffer_usage_begin  //
+      if constexpr(detail::check_valid_element_access)
+      {
+      if(N <= index) [[unlikely]]
+        detail::report_invalid_element_access("out of bounds element access ", N, index);
+      }
     return data_[index];
+    small_vectors_clang_unsafe_buffer_usage_end  //
     }
 
   [[nodiscard]]
   inline constexpr auto at(concepts::unsigned_arithmetic_integral auto index) const noexcept -> char_type const &
     {
+    small_vectors_clang_unsafe_buffer_usage_begin  //
+      if constexpr(detail::check_valid_element_access)
+      {
+      if(N <= index) [[unlikely]]
+        detail::report_invalid_element_access("out of bounds element access ", N, index);
+      }
     return data_[index];
+    small_vectors_clang_unsafe_buffer_usage_end  //
     }
 
   [[nodiscard]]
   inline constexpr auto at(concepts::unsigned_arithmetic_integral auto index) noexcept -> char_type &
     {
+    small_vectors_clang_unsafe_buffer_usage_begin  //
+      if constexpr(detail::check_valid_element_access)
+      {
+      if(N <= index) [[unlikely]]
+        detail::report_invalid_element_access("out of bounds element access ", N, index);
+      }
     return data_[index];
+    small_vectors_clang_unsafe_buffer_usage_end  //
     }
 
   constexpr basic_fixed_string() noexcept = default;
@@ -100,7 +132,9 @@ struct basic_fixed_string
     requires(!std::same_as<other_char_type, char_type>)
   constexpr basic_fixed_string(other_char_type const (&foo)[N + 1]) noexcept
     {
-    std::transform(foo, foo + N + 1, data_, [](other_char_type c) noexcept { return static_cast<char_type>(c); });
+    small_vectors_clang_unsafe_buffer_usage_begin  //
+      std::transform(foo, foo + N + 1, data_, [](other_char_type c) noexcept { return static_cast<char_type>(c); });
+    small_vectors_clang_unsafe_buffer_usage_end  //
     }
 
   constexpr auto view() const noexcept -> std::basic_string_view<char_type> { return {&data_[0], N}; }

--- a/include/small_vectors/basic_fixed_string.h
+++ b/include/small_vectors/basic_fixed_string.h
@@ -8,7 +8,7 @@
 #include <algorithm>
 #include <array>
 
-namespace small_vectors::inline v3_0
+namespace small_vectors::inline v3_2
   {
 
 template<concepts::integral_or_byte CharType, std::size_t N>
@@ -202,4 +202,4 @@ inline consteval auto cast_fixed_string(char_type const (&str)[N]) noexcept -> b
   return basic_fixed_string<decl_chr_type, N - 1>(str);
   }
 
-  }  // namespace small_vectors::inline v3_0
+  }  // namespace small_vectors::inline v3_2

--- a/include/small_vectors/basic_string.h
+++ b/include/small_vectors/basic_string.h
@@ -29,7 +29,7 @@
 #include <numeric>
 #include <compare>
 
-namespace small_vectors::inline v3_0
+namespace small_vectors::inline v3_2
   {
 using detail::string::buffered_string_tag;
 using detail::string::static_string_tag;
@@ -743,7 +743,7 @@ inline constexpr auto hash(basic_string_t<V, N, T> const & str) noexcept
   else
     return std::hash<std::basic_string_view<V>>()(str.view());
   }
-  }  // namespace small_vectors::inline v3_0
+  }  // namespace small_vectors::inline v3_2
 
 namespace std
   {

--- a/include/small_vectors/basic_string.h
+++ b/include/small_vectors/basic_string.h
@@ -165,9 +165,8 @@ struct basic_string_t
     }
 
   [[nodiscard]]
-  inline constexpr auto c_str() const noexcept -> value_type const * requires(detail::string::null_terminate_string) {
-    return storage_.data();
-  }
+  inline constexpr auto c_str() const noexcept
+    -> value_type const * requires(detail::string::null_terminate_string) { return storage_.data(); }
 
   /// \returns The largest possible number of char-like objects that can be stored in a basic_string.
   [[nodiscard]] inline static constexpr auto max_size() noexcept -> size_type
@@ -268,28 +267,36 @@ struct basic_string_t
   constexpr ~basic_string_t() { detail::string::storage_cleanup<storage_tag>(storage_); }
 
   [[nodiscard]]
-  inline constexpr auto operator[](concepts::unsigned_arithmetic_integral auto index
-  ) const noexcept -> char_type const &
+  inline constexpr auto operator[](concepts::unsigned_arithmetic_integral auto index) const noexcept
+    -> char_type const &
     {
-    return data()[index];
+    small_vectors_clang_unsafe_buffer_usage_begin  //
+      return data()[index];
+    small_vectors_clang_unsafe_buffer_usage_end  //
     }
 
   [[nodiscard]]
   inline constexpr auto operator[](concepts::unsigned_arithmetic_integral auto index) noexcept -> char_type &
     {
-    return data()[index];
+    small_vectors_clang_unsafe_buffer_usage_begin  //
+      return data()[index];
+    small_vectors_clang_unsafe_buffer_usage_end  //
     }
 
   [[nodiscard]]
   inline constexpr auto at(concepts::unsigned_arithmetic_integral auto index) const noexcept -> char_type const &
     {
-    return data()[index];
+    small_vectors_clang_unsafe_buffer_usage_begin  //
+      return data()[index];
+    small_vectors_clang_unsafe_buffer_usage_end  //
     }
 
   [[nodiscard]]
   inline constexpr auto at(concepts::unsigned_arithmetic_integral auto index) noexcept -> char_type &
     {
-    return data()[index];
+    small_vectors_clang_unsafe_buffer_usage_begin  //
+      return data()[index];
+    small_vectors_clang_unsafe_buffer_usage_end  //
     }
 
   // compatibility with old code
@@ -412,9 +419,9 @@ struct basic_string_t
     return *this;
     }
 
-  inline constexpr auto append(
-    std::convertible_to<view_type> auto const & s, size_type index_str, size_type count = npos
-  ) -> basic_string_t &
+  inline constexpr auto
+    append(std::convertible_to<view_type> auto const & s, size_type index_str, size_type count = npos)
+      -> basic_string_t &
     {
     view_type t{static_cast<view_type>(s).substr(index_str, count)};
     append(t);
@@ -498,8 +505,8 @@ struct basic_string_t
     return static_cast<size_type>(view().find(ch, pos));
     }
 
-  inline constexpr auto
-    find(std::convertible_to<view_type> auto const & s, size_type pos = 0u) const noexcept -> size_type
+  inline constexpr auto find(std::convertible_to<view_type> auto const & s, size_type pos = 0u) const noexcept
+    -> size_type
     {
     return static_cast<size_type>(view().find(static_cast<view_type>(s), pos));
     }
@@ -516,8 +523,8 @@ struct basic_string_t
     return static_cast<size_type>(view().rfind(ch, pos));
     }
 
-  inline constexpr auto
-    rfind(std::convertible_to<view_type> auto const & s, size_type pos = npos) const noexcept -> size_type
+  inline constexpr auto rfind(std::convertible_to<view_type> auto const & s, size_type pos = npos) const noexcept
+    -> size_type
     {
     return static_cast<size_type>(view().rfind(static_cast<view_type>(s), pos));
     }
@@ -540,14 +547,14 @@ struct basic_string_t
     return view().compare(pos1, count1, static_cast<view_type>(s));
     }
 
-  inline constexpr auto
-    find_first_of(std::convertible_to<view_type> auto const & v, size_type pos = 0u) const noexcept -> size_type
+  inline constexpr auto find_first_of(std::convertible_to<view_type> auto const & v, size_type pos = 0u) const noexcept
+    -> size_type
     {
     return static_cast<size_type>(view().find_first_of(static_cast<view_type>(v), pos));
     }
 
-  constexpr auto
-    replace(size_type pos, size_type count, std::convertible_to<view_type> auto const & v) -> basic_string_t &
+  constexpr auto replace(size_type pos, size_type count, std::convertible_to<view_type> auto const & v)
+    -> basic_string_t &
     {
     detail::string::replace_copy(storage_, pos, count, v.begin(), v.end());
     return *this;
@@ -555,8 +562,8 @@ struct basic_string_t
 
   template<std::forward_iterator iterator>
     requires std::same_as<char_type, std::iter_value_t<iterator>>
-  inline constexpr auto
-    replace(const_iterator first, const_iterator last, iterator first2, iterator last2) -> basic_string_t &
+  inline constexpr auto replace(const_iterator first, const_iterator last, iterator first2, iterator last2)
+    -> basic_string_t &
     {
     auto pos{static_cast<size_type>(std::distance(cbegin(), first))};
     auto count{static_cast<size_type>(std::distance(first, last))};
@@ -564,9 +571,9 @@ struct basic_string_t
     return *this;
     }
 
-  inline constexpr auto replace(
-    const_iterator first, const_iterator last, std::convertible_to<view_type> auto const & v
-  ) -> basic_string_t &
+  inline constexpr auto
+    replace(const_iterator first, const_iterator last, std::convertible_to<view_type> auto const & v)
+      -> basic_string_t &
     {
     auto pos{static_cast<size_type>(std::distance(cbegin(), first))};
     auto count{static_cast<size_type>(std::distance(first, last))};
@@ -579,8 +586,8 @@ struct basic_string_t
     return *this;
     }
 
-  inline constexpr auto
-    replace(const_iterator first, const_iterator last, size_type count2, char_type ch) -> basic_string_t &
+  inline constexpr auto replace(const_iterator first, const_iterator last, size_type count2, char_type ch)
+    -> basic_string_t &
     {
     auto pos{static_cast<size_type>(std::distance(cbegin(), first))};
     auto count{static_cast<size_type>(std::distance(first, last))};
@@ -588,9 +595,9 @@ struct basic_string_t
     }
 
   ///\brief replaces all occurrences of \ref what with \ref with
-  inline constexpr auto find_and_replace(
-    std::convertible_to<view_type> auto const & what, std::convertible_to<view_type> auto const & with
-  ) -> size_type
+  inline constexpr auto
+    find_and_replace(std::convertible_to<view_type> auto const & what, std::convertible_to<view_type> auto const & with)
+      -> size_type
     {
     size_type const what_size = static_cast<size_type>(what.size());
     size_type const with_size = static_cast<size_type>(with.size());
@@ -704,15 +711,15 @@ constexpr auto operator==(basic_string_t<V, N, T> const & l, std::basic_string_v
   }
 
 template<typename V, uint64_t N, typename T>
-constexpr auto
-  operator<=>(basic_string_t<V, N, T> const & l, basic_string_t<V, N, T> const & r) noexcept -> std::strong_ordering
+constexpr auto operator<=>(basic_string_t<V, N, T> const & l, basic_string_t<V, N, T> const & r) noexcept
+  -> std::strong_ordering
   {
   return l.view() <=> r.view();
   }
 
 template<typename V, uint64_t N, typename T>
-constexpr auto
-  operator<=>(basic_string_t<V, N, T> const & l, std::basic_string_view<V> r) noexcept -> std::strong_ordering
+constexpr auto operator<=>(basic_string_t<V, N, T> const & l, std::basic_string_view<V> r) noexcept
+  -> std::strong_ordering
   {
   return l.view() <=> r;
   }

--- a/include/small_vectors/composed_pointer_with_data.h
+++ b/include/small_vectors/composed_pointer_with_data.h
@@ -6,7 +6,7 @@
 #include <cassert>
 #include <bit>
 
-namespace small_vectors::inline v3_0
+namespace small_vectors::inline v3_2
   {
 template<typename T, concepts::trivial V>
 //     requires( alignof(T) > 1 ) //disabled due to not being able use declaration for recurent types
@@ -64,4 +64,4 @@ struct composed_pointer_with_data
     data_ = (data_ & pointer_mask) | static_cast<uintptr_t>(value);
     }
   };
-  }  // namespace small_vectors::inline v3_0
+  }  // namespace small_vectors::inline v3_2

--- a/include/small_vectors/concepts/concepts.h
+++ b/include/small_vectors/concepts/concepts.h
@@ -5,7 +5,7 @@
 #include <cstdint>
 #include <iterator>
 
-namespace small_vectors::inline v3_0::concepts
+namespace small_vectors::inline v3_2::concepts
   {
 using std::convertible_to;
 
@@ -227,4 +227,4 @@ template<typename T>
 concept has_bitwise_or_assign = requires(T a, T const & b) {
   { a |= b } -> same_as_any_of<T &, T const &>;
 };
-  }  // namespace small_vectors::inline v3_0::concepts
+  }  // namespace small_vectors::inline v3_2::concepts

--- a/include/small_vectors/concepts/hashable.h
+++ b/include/small_vectors/concepts/hashable.h
@@ -4,12 +4,10 @@
 #include <concepts>
 #include <functional>
 
-namespace small_vectors::inline v3_0::concepts
+namespace small_vectors::inline v3_2::concepts
   {
 template<typename value_type>
 concept hashable = requires(value_type value) {
-  {
-  std::hash<value_type>{}(value)
-  } -> std::convertible_to<std::size_t>;
+  { std::hash<value_type>{}(value) } -> std::convertible_to<std::size_t>;
 };
-  }
+  }  // namespace small_vectors::inline v3_2::concepts

--- a/include/small_vectors/concepts/integral_or_byte.h
+++ b/include/small_vectors/concepts/integral_or_byte.h
@@ -4,7 +4,7 @@
 #include <concepts>
 #include <cstddef>
 
-namespace small_vectors::inline v3_0::concepts
+namespace small_vectors::inline v3_2::concepts
   {
 template<typename value_type>
 concept integral_or_byte = std::integral<value_type> || std::is_same_v<value_type, std::byte>;

--- a/include/small_vectors/concepts/iterator_traits.h
+++ b/include/small_vectors/concepts/iterator_traits.h
@@ -4,7 +4,7 @@
 #include <iterator>
 #include <type_traits>
 
-namespace small_vectors::inline v3_0::concepts
+namespace small_vectors::inline v3_2::concepts
   {
 template<typename iterator_type>
 concept iterator_traits_defined = requires {
@@ -15,4 +15,4 @@ concept iterator_traits_defined = requires {
   typename std::iterator_traits<iterator_type>::iterator_category;
 };
 
-  }
+  }  // namespace small_vectors::inline v3_2::concepts

--- a/include/small_vectors/concepts/numeric_limits.h
+++ b/include/small_vectors/concepts/numeric_limits.h
@@ -2,13 +2,11 @@
 #include <limits>
 #include <type_traits>
 
-namespace small_vectors::inline v3_0::concepts
+namespace small_vectors::inline v3_2::concepts
   {
 template<typename value_type>
 concept has_numeric_limits_max = requires {
-  {
-  std::numeric_limits<value_type>::max()
-  } -> std::convertible_to<value_type>;
+  { std::numeric_limits<value_type>::max() } -> std::convertible_to<value_type>;
 };
-  }
+  }  // namespace small_vectors::inline v3_2::concepts
 

--- a/include/small_vectors/concepts/stream_insertable.h
+++ b/include/small_vectors/concepts/stream_insertable.h
@@ -2,12 +2,10 @@
 #include <concepts>
 #include <iosfwd>
 
-namespace small_vectors::inline v3_0::concepts
+namespace small_vectors::inline v3_2::concepts
   {
 template<typename value_type>
 concept stream_insertable = requires(std::ostream & os, value_type const & value) {
-  {
-  os << value
-  } -> std::same_as<std::ostream &>;
+  { os << value } -> std::same_as<std::ostream &>;
 };
-  }
+  }  // namespace small_vectors::inline v3_2::concepts

--- a/include/small_vectors/detail/adapter_iterator.h
+++ b/include/small_vectors/detail/adapter_iterator.h
@@ -2,7 +2,7 @@
 #include <small_vectors/concepts/iterator_traits.h>
 #include <concepts>
 
-namespace small_vectors::inline v3_0::detail
+namespace small_vectors::inline v3_2::detail
   {
 /// \brief adapter for wrapping use of pointer arithmetic
 template<std::input_iterator Iterator>
@@ -193,4 +193,4 @@ inline constexpr auto
   {
   return adapter_iterator<iter1>(i.base() + n);
   }
-  }  // namespace small_vectors::inline v3_0::detail
+  }  // namespace small_vectors::inline v3_2::detail

--- a/include/small_vectors/detail/adapter_iterator.h
+++ b/include/small_vectors/detail/adapter_iterator.h
@@ -32,15 +32,13 @@ struct adapter_iterator
 
   // forward
   [[nodiscard]]
-  inline constexpr auto
-    operator*() const noexcept -> reference
+  inline constexpr auto operator*() const noexcept -> reference
     {
     return *current_;
     }
 
   [[nodiscard]]
-  inline constexpr auto
-    operator->() const noexcept -> pointer
+  inline constexpr auto operator->() const noexcept -> pointer
     {
     return current_;
     }
@@ -48,13 +46,18 @@ struct adapter_iterator
   inline constexpr auto operator++() noexcept -> adapter_iterator &
     requires std::forward_iterator<iterator_type>
     {
+#ifdef __clang__
+#pragma clang unsafe_buffer_usage begin
+#endif
     ++current_;
+#ifdef __clang__
+#pragma clang unsafe_buffer_usage end
+#endif
     return *this;
     }
 
   [[nodiscard]]
-  inline constexpr auto
-    operator++(int) noexcept -> adapter_iterator
+  inline constexpr auto operator++(int) noexcept -> adapter_iterator
     requires std::forward_iterator<iterator_type>
     {
     return adapter_iterator{current_++};
@@ -64,13 +67,18 @@ struct adapter_iterator
   inline constexpr auto operator--() noexcept -> adapter_iterator &
     requires std::bidirectional_iterator<iterator_type>
     {
+#ifdef __clang__
+#pragma clang unsafe_buffer_usage begin
+#endif
     --current_;
+#ifdef __clang__
+#pragma clang unsafe_buffer_usage end
+#endif
     return *this;
     }
 
   [[nodiscard]]
-  inline constexpr auto
-    operator--(int) noexcept -> adapter_iterator
+  inline constexpr auto operator--(int) noexcept -> adapter_iterator
     requires std::bidirectional_iterator<iterator_type>
     {
     return adapter_iterator{current_--};
@@ -78,41 +86,68 @@ struct adapter_iterator
 
   // random
   [[nodiscard]]
-  inline constexpr auto
-    operator[](std::size_t index) const noexcept -> reference
+  inline constexpr auto operator[](std::size_t index) const noexcept -> reference
     requires std::random_access_iterator<iterator_type>
     {
+#ifdef __clang__
+#pragma clang unsafe_buffer_usage begin
+#endif
     return current_[index];
+#ifdef __clang__
+#pragma clang unsafe_buffer_usage end
+#endif
     }
 
   inline constexpr auto operator+=(difference_type index) noexcept -> adapter_iterator &
     requires std::random_access_iterator<iterator_type>
     {
+#ifdef __clang__
+#pragma clang unsafe_buffer_usage begin
+#endif
     current_ += index;
+#ifdef __clang__
+#pragma clang unsafe_buffer_usage end
+#endif
     return *this;
     }
 
   [[nodiscard]]
-  inline constexpr auto
-    operator+(difference_type index) const noexcept -> adapter_iterator
+  inline constexpr auto operator+(difference_type index) const noexcept -> adapter_iterator
     requires std::random_access_iterator<iterator_type>
     {
+#ifdef __clang__
+#pragma clang unsafe_buffer_usage begin
+#endif
     return adapter_iterator(current_ + index);
+#ifdef __clang__
+#pragma clang unsafe_buffer_usage end
+#endif
     }
 
   inline constexpr auto operator-=(difference_type index) noexcept -> adapter_iterator &
     requires std::random_access_iterator<iterator_type>
     {
+#ifdef __clang__
+#pragma clang unsafe_buffer_usage begin
+#endif
     current_ -= index;
+#ifdef __clang__
+#pragma clang unsafe_buffer_usage end
+#endif
     return *this;
     }
 
   [[nodiscard]]
-  inline constexpr auto
-    operator-(difference_type index) const noexcept -> adapter_iterator
+  inline constexpr auto operator-(difference_type index) const noexcept -> adapter_iterator
     requires std::random_access_iterator<iterator_type>
     {
+#ifdef __clang__
+#pragma clang unsafe_buffer_usage begin
+#endif
     return adapter_iterator(current_ - index);
+#ifdef __clang__
+#pragma clang unsafe_buffer_usage end
+#endif
     }
 
   [[nodiscard]]
@@ -127,28 +162,25 @@ adapter_iterator(iterator_type const & i) -> adapter_iterator<iterator_type>;
 
 template<typename iter1, std::equality_comparable_with<iter1> iter2>
 [[nodiscard]]
-inline constexpr auto
-  operator==(adapter_iterator<iter1> const & l, adapter_iterator<iter2> const & r) noexcept(
-    noexcept(l.base() == r.base())
-  ) -> bool
+inline constexpr auto operator==(adapter_iterator<iter1> const & l, adapter_iterator<iter2> const & r) noexcept(
+  noexcept(l.base() == r.base())
+) -> bool
   {
   return l.base() == r.base();
   }
 
 template<typename iter1, std::totally_ordered_with<iter1> iter2>
 [[nodiscard]]
-inline constexpr auto
-  operator<=>(adapter_iterator<iter1> const & l, adapter_iterator<iter2> const & r) noexcept(
-    noexcept(l.base() <=> r.base())
-  )
+inline constexpr auto operator<=>(adapter_iterator<iter1> const & l, adapter_iterator<iter2> const & r) noexcept(
+  noexcept(l.base() <=> r.base())
+)
   {
   return l.base() <=> r.base();
   }
 
 template<typename iter1, typename iter2>
 [[nodiscard]]
-inline constexpr auto
-  operator-(adapter_iterator<iter1> const & l, adapter_iterator<iter2> const & r) noexcept
+inline constexpr auto operator-(adapter_iterator<iter1> const & l, adapter_iterator<iter2> const & r) noexcept
   {
   return l.base() - r.base();
   }

--- a/include/small_vectors/detail/safe_buffers.h
+++ b/include/small_vectors/detail/safe_buffers.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <small_vectors/version.h>
+#include <string_view>
+#include <source_location>
+
+#if !defined(SMALL_VECTORS_CHECK_VALID_ELEMENT_ACCESS)
+#define SMALL_VECTORS_CHECK_VALID_ELEMENT_ACCESS true
+#endif
+
+namespace small_vectors::inline v3_0::detail
+  {
+// motivated by to https://libcxx.llvm.org/Hardening.html
+// checks that any attempts to access a container element, whether through the container object or through an iterator,
+// are valid and do not attempt to go out of bounds or otherwise access a non-existent element.
+inline constexpr bool check_valid_element_access{SMALL_VECTORS_CHECK_VALID_ELEMENT_ACCESS};
+
+[[noreturn]]
+void report_invalid_element_access(
+  std::string_view, std::size_t size, std::size_t index, std::source_location loc = std::source_location::current()
+);
+  }  // namespace small_vectors::inline v3_0::detail

--- a/include/small_vectors/detail/safe_buffers.h
+++ b/include/small_vectors/detail/safe_buffers.h
@@ -8,7 +8,7 @@
 #define SMALL_VECTORS_CHECK_VALID_ELEMENT_ACCESS true
 #endif
 
-namespace small_vectors::inline v3_0::detail
+namespace small_vectors::inline v3_2::detail
   {
 // motivated by to https://libcxx.llvm.org/Hardening.html
 // checks that any attempts to access a container element, whether through the container object or through an iterator,
@@ -19,4 +19,4 @@ inline constexpr bool check_valid_element_access{SMALL_VECTORS_CHECK_VALID_ELEME
 void report_invalid_element_access(
   std::string_view, std::size_t size, std::size_t index, std::source_location loc = std::source_location::current()
 );
-  }  // namespace small_vectors::inline v3_0::detail
+  }  // namespace small_vectors::inline v3_2::detail

--- a/include/small_vectors/detail/string_func.h
+++ b/include/small_vectors/detail/string_func.h
@@ -7,7 +7,7 @@
 #include <ranges>
 #include <small_vectors/utils/static_call_operator.h>
 
-namespace small_vectors::inline v3_0::detail::string
+namespace small_vectors::inline v3_2::detail::string
   {
 struct static_string_tag
   {
@@ -794,5 +794,5 @@ struct pop_back_t
 
 inline constexpr pop_back_t pop_back;
 
-  }  // namespace small_vectors::inline v3_0::detail::string
+  }  // namespace small_vectors::inline v3_2::detail::string
 

--- a/include/small_vectors/detail/string_func.h
+++ b/include/small_vectors/detail/string_func.h
@@ -1,5 +1,5 @@
 #pragma once
-
+#include <small_vectors/version.h>
 #include <small_vectors/detail/vector_func.h>
 #include <algorithm>
 #include <string_view>
@@ -45,8 +45,8 @@ struct growth_t
   {
   template<typename size_type>
   [[nodiscard]]
-  small_vector_static_call_operator constexpr auto
-    operator()(size_type new_elements) small_vector_static_call_operator_const noexcept -> size_type
+  small_vector_static_call_operator constexpr auto operator()(size_type new_elements
+  ) small_vector_static_call_operator_const noexcept -> size_type
     {
     auto byte_size = static_cast<size_type>(sizeof(char_type) * new_elements);
     return static_cast<size_type>((((byte_size + 8u) >> 3) << 3) / sizeof(char_type));
@@ -72,7 +72,11 @@ struct cond_null_terminate_t
     operator()(char_type * data, size_type new_size) small_vector_static_call_operator_const noexcept
     {
     if constexpr(null_terminate_string)
-      uninitialized_value_construct(data + new_size);
+      {
+      small_vectors_clang_unsafe_buffer_usage_begin  //
+        uninitialized_value_construct(data + new_size);
+      small_vectors_clang_unsafe_buffer_usage_end  //
+      }
     }
   };
 
@@ -112,8 +116,10 @@ struct shrink_to_fit_t
           {
           auto old_strage_data{storage.data()};
           storage_context_t new_space{sv_allocate<char_type>(optimal_capacity)};
-          uninitialized_copy(old_strage_data, old_strage_data + storage.size_, new_space.data);
-          storage_context_t old_storage{storage.exchange_priv_(new_space, storage.size_)};
+          small_vectors_clang_unsafe_buffer_usage_begin  //
+            uninitialized_copy(old_strage_data, old_strage_data + storage.size_, new_space.data);
+          small_vectors_clang_unsafe_buffer_usage_end  //
+            storage_context_t old_storage{storage.exchange_priv_(new_space, storage.size_)};
           assert(old_storage.data != nullptr);
           sv_deallocate(old_storage);
           }
@@ -124,9 +130,12 @@ struct shrink_to_fit_t
         storage_context_t old_storage{storage.switch_static_priv_()};
         assert(old_storage.data != nullptr);
         auto data{storage.data()};
-        uninitialized_copy(old_storage.data, old_storage.data + size, data);
+        small_vectors_clang_unsafe_buffer_usage_begin  //
+          uninitialized_copy(old_storage.data, old_storage.data + size, data);
         cond_null_terminate(data + size);
-        storage.size_ = size;
+        small_vectors_clang_unsafe_buffer_usage_end  //
+          storage.size_
+          = size;
         sv_deallocate(old_storage);
         }
       }
@@ -141,9 +150,9 @@ struct uninitialized_construct_t
   {
   template<typename lambda>
   [[nodiscard]]
-  small_vector_static_call_operator inline constexpr auto
-    operator()(typename vector_storage::size_type sz, lambda const & uninitialized_fn)
-      small_vector_static_call_operator_const->vector_storage
+  small_vector_static_call_operator inline constexpr auto operator()(
+    typename vector_storage::size_type sz, lambda const & uninitialized_fn
+  ) small_vector_static_call_operator_const->vector_storage
     {
     vector_storage storage;
 
@@ -170,8 +179,11 @@ struct uninitialized_construct_t
       auto dest_data{storage.data()};
       // in constant evaluated buffer must be initialized even when unused
       if(std::is_constant_evaluated())
-        uninitialized_default_construct(dest_data, dest_data + storage.buffered_capacity);
-
+        {
+        small_vectors_clang_unsafe_buffer_usage_begin  //
+          uninitialized_default_construct(dest_data, dest_data + storage.buffered_capacity);
+        small_vectors_clang_unsafe_buffer_usage_end  //
+        }
       auto last = uninitialized_fn(dest_data);
       cond_null_terminate(last);
 
@@ -243,8 +255,8 @@ struct swap_t
     operator()(vector_storage & lstorage, vector_storage & rstorage) small_vector_static_call_operator_const noexcept
     {
     lstorage.swap(rstorage);
-    cond_null_terminate(lstorage.data() + lstorage.size_);
-    cond_null_terminate(rstorage.data() + rstorage.size_);
+    cond_null_terminate(lstorage.data(), lstorage.size_);
+    cond_null_terminate(rstorage.data(), rstorage.size_);
     }
   };
 
@@ -293,8 +305,8 @@ template<detail_concepts::vector_storage vector_storage>
 struct value_construct_t
   {
   [[nodiscard]]
-  small_vector_static_call_operator inline constexpr auto
-    operator()(typename vector_storage::size_type sz) small_vector_static_call_operator_const->vector_storage
+  small_vector_static_call_operator inline constexpr auto operator()(typename vector_storage::size_type sz
+  ) small_vector_static_call_operator_const->vector_storage
     {
     return uninitialized_construct<vector_storage>(
       sz, [sz](auto * data) noexcept { return uninitialized_value_construct(data, data + sz); }
@@ -310,12 +322,18 @@ template<detail_concepts::vector_storage vector_storage>
 struct fill_construct_t
   {
   [[nodiscard]]
-  small_vector_static_call_operator inline constexpr auto
-    operator()(typename vector_storage::size_type sz, typename vector_storage::value_type ch)
-      small_vector_static_call_operator_const->vector_storage
+  small_vector_static_call_operator inline constexpr auto operator()(
+    typename vector_storage::size_type sz, typename vector_storage::value_type ch
+  ) small_vector_static_call_operator_const->vector_storage
     {
     return uninitialized_construct<vector_storage>(
-      sz, [sz, ch](auto * data) noexcept { return uninitialized_fill(data, data + sz, ch); }
+      sz,
+      [sz, ch](auto * data) noexcept
+      {
+        small_vectors_clang_unsafe_buffer_usage_begin  //
+          return uninitialized_fill(data, data + sz, ch);
+        small_vectors_clang_unsafe_buffer_usage_end  //
+      }
     );
     }
   };
@@ -332,7 +350,14 @@ struct fill_assign_t
   ) small_vector_static_call_operator_const
     {
     uninitialized_assign(
-      storage, sz, [sz, ch](auto * data) noexcept { return uninitialized_fill(data, data + sz, ch); }
+      storage,
+      sz,
+      [sz, ch](auto * data) noexcept
+      {
+        small_vectors_clang_unsafe_buffer_usage_begin  //
+          return uninitialized_fill(data, data + sz, ch);
+        small_vectors_clang_unsafe_buffer_usage_end  //
+      }
     );
     }
   };
@@ -357,8 +382,10 @@ struct reserve_t
         auto new_capacity{growth<char_type>(raw_size)};
         storage_context_t new_space{sv_allocate<char_type>(new_capacity)};
         auto first{storage.data()};
-        auto last{first + storage.size_ + null_termination};
-        uninitialized_copy(first, last, new_space.data);  // copies conditionally null termination
+        small_vectors_clang_unsafe_buffer_usage_begin  //
+          auto last{first + storage.size_ + null_termination};
+        small_vectors_clang_unsafe_buffer_usage_end         //
+          uninitialized_copy(first, last, new_space.data);  // copies conditionally null termination
 
         // deallocate old space
         storage_context_t old_storage{storage.exchange_priv_(new_space, storage.size_)};
@@ -389,7 +416,7 @@ struct resize_and_overwrite_t
       {
       auto data{storage.data()};
       typename vector_storage::size_type new_size{op(data, storage.capacity())};
-      cond_null_terminate(data + new_size);
+      cond_null_terminate(data, new_size);
       storage.size_ = new_size;
       }
     else if constexpr(vector_storage::supports_reallocation)
@@ -397,15 +424,19 @@ struct resize_and_overwrite_t
       auto new_capacity{growth<char_type>(raw_size)};
       storage_context_t new_space{sv_allocate<char_type>(new_capacity)};
       auto data{storage.data()};
-      uninitialized_copy(data, data + storage.size_, new_space.data);
-      if(std::is_constant_evaluated())
+      small_vectors_clang_unsafe_buffer_usage_begin  //
+        uninitialized_copy(data, data + storage.size_, new_space.data);
+      small_vectors_clang_unsafe_buffer_usage_end  //
+        if(std::is_constant_evaluated())
         {
         // for constant evaluated mode we have to initialize storage to allow user operator assignment
         // in constant evaluated mode assignment to uninitialized store is not allowed
-        uninitialized_value_construct(new_space.data + storage.size_, new_space.data + new_capacity);
+        small_vectors_clang_unsafe_buffer_usage_begin  //
+          uninitialized_value_construct(new_space.data + storage.size_, new_space.data + new_capacity);
+        small_vectors_clang_unsafe_buffer_usage_end  //
         }
       typename vector_storage::size_type new_size{op(new_space.data, new_capacity - null_termination)};
-      cond_null_terminate(new_space.data + new_size);
+      cond_null_terminate(new_space.data, new_size);
 
       // deallocate old space
       storage_context_t old_storage{storage.exchange_priv_(new_space, new_size)};
@@ -435,7 +466,11 @@ struct resize_t
       [old_size = storage.size_, sz](char_type * data, size_type /*buff_cap*/) noexcept -> size_type
       {
         if(sz > old_size)
-          uninitialized_value_construct(data + old_size, data + sz);
+          {
+          small_vectors_clang_unsafe_buffer_usage_begin  //
+            uninitialized_value_construct(data + old_size, data + sz);
+          small_vectors_clang_unsafe_buffer_usage_end  //
+          }
         return sz;
       }
     );
@@ -455,7 +490,11 @@ struct resize_t
       [old_size = storage.size_, sz, ch](char_type * data, size_type /*buff_cap*/) noexcept -> size_type
       {
         if(sz > old_size)
-          uninitialized_fill(data + old_size, data + sz, ch);
+          {
+          small_vectors_clang_unsafe_buffer_usage_begin  //
+            uninitialized_fill(data + old_size, data + sz, ch);
+          small_vectors_clang_unsafe_buffer_usage_end  //
+          }
         return sz;
       }
     );
@@ -493,16 +532,22 @@ struct replace_aux_t
       char_type * data{storage.data()};
       if(old_size == new_size) {}
       else if(old_size > new_size)
-        uninitialized_copy(data + pos + old_size, data + storage.size_, data + pos + new_size);
-      else
+        small_vectors_clang_unsafe_buffer_usage_begin  //
+          uninitialized_copy(data + pos + old_size, data + storage.size_, data + pos + new_size);
+      small_vectors_clang_unsafe_buffer_usage_end  //
+        else
         {
-        auto ito_end{std::reverse_iterator{data + pos + old_size}};
+        small_vectors_clang_unsafe_buffer_usage_begin  //
+          auto ito_end{std::reverse_iterator{data + pos + old_size}};
         auto ito_begin{std::reverse_iterator{data + storage.size_}};
         auto itn_begin{std::reverse_iterator{data + storage.size_ - old_size + new_size}};
-        uninitialized_copy(ito_begin, ito_end, itn_begin);
+        small_vectors_clang_unsafe_buffer_usage_end  //
+          uninitialized_copy(ito_begin, ito_end, itn_begin);
         }
-      op(data + pos);
-      cond_null_terminate(data + str_new_size);
+      small_vectors_clang_unsafe_buffer_usage_begin  //
+        op(data + pos);
+      small_vectors_clang_unsafe_buffer_usage_end  //
+        cond_null_terminate(data, str_new_size);
       storage.size_ = str_new_size;
       }
     else if constexpr(vector_storage::supports_reallocation)
@@ -510,10 +555,13 @@ struct replace_aux_t
       size_type new_capacity{growth<char_type>(raw_size)};
       storage_context_t new_space{sv_allocate<char_type>(new_capacity)};
       char_type * data{storage.data()};
-      uninitialized_copy(data, data + pos, new_space.data);
+
+      small_vectors_clang_unsafe_buffer_usage_begin  //
+        uninitialized_copy(data, data + pos, new_space.data);
       op(new_space.data + pos);
       uninitialized_copy(data + pos + old_size, data + storage.size_, new_space.data + pos + new_size);
-      cond_null_terminate(new_space.data + str_new_size);
+      small_vectors_clang_unsafe_buffer_usage_end  //
+        cond_null_terminate(new_space.data, str_new_size);
       // deallocate old space
       storage_context_t old_storage{storage.exchange_priv_(new_space, str_new_size)};
       if(old_storage.data != nullptr) [[unlikely]]
@@ -571,7 +619,12 @@ struct replace_fill_t
       pos,
       count,
       count2,
-      [count2, ch](char_type * data) noexcept { uninitialized_fill(data, data + count2, ch); }
+      [count2, ch](char_type * data) noexcept
+      {
+        small_vectors_clang_unsafe_buffer_usage_begin  //
+          uninitialized_fill(data, data + count2, ch);
+        small_vectors_clang_unsafe_buffer_usage_end  //
+      }
     );
     }
   };
@@ -597,7 +650,12 @@ struct insert_fill_t
       pos,
       size_type(0u),
       count,
-      [count, ch](char_type * data) noexcept { uninitialized_fill(data, data + count, ch); }
+      [count, ch](char_type * data) noexcept
+      {
+        small_vectors_clang_unsafe_buffer_usage_begin  //
+          uninitialized_fill(data, data + count, ch);
+        small_vectors_clang_unsafe_buffer_usage_end  //
+      }
     );
     }
   };
@@ -643,8 +701,10 @@ struct append_fill_t
       new_size,
       [old_size = storage.size_, new_size, ch](char_type * data, size_type /*buff_cap*/) noexcept -> size_type
       {
-        uninitialized_fill(data + old_size, data + new_size, ch);
-        return new_size;
+        small_vectors_clang_unsafe_buffer_usage_begin  //
+          uninitialized_fill(data + old_size, data + new_size, ch);
+        small_vectors_clang_unsafe_buffer_usage_end  //
+          return new_size;
       }
     );
     }
@@ -668,8 +728,10 @@ struct append_copy_t
       new_size,
       [old_size = storage.size_, new_size, first, last](char_type * data, size_type /*buff_cap*/) noexcept -> size_type
       {
-        uninitialized_copy(first, last, data + old_size);
-        return new_size;
+        small_vectors_clang_unsafe_buffer_usage_begin  //
+          uninitialized_copy(first, last, data + old_size);
+        small_vectors_clang_unsafe_buffer_usage_end  //
+          return new_size;
       }
     );
     }
@@ -705,9 +767,12 @@ struct erase_t
     count = std::min<size_type>(count, storage.size_ - index);
     size_type rpos = index + count;
     char_type * data{storage.data()};
-    std::ranges::copy(data + rpos, data + storage.size_, data + index);
-    storage.size_ -= count;
-    cond_null_terminate(data + storage.size_);
+    small_vectors_clang_unsafe_buffer_usage_begin  //
+      std::ranges::copy(data + rpos, data + storage.size_, data + index);
+    small_vectors_clang_unsafe_buffer_usage_end  //
+      storage.size_
+      -= count;
+    cond_null_terminate(data, storage.size_);
     }
   };
 
@@ -723,7 +788,7 @@ struct pop_back_t
     using char_type = typename vector_storage::value_type;
     char_type * data{storage.data()};
     storage.size_ -= 1u;
-    cond_null_terminate(data + storage.size_);
+    cond_null_terminate(data, storage.size_);
     }
   };
 

--- a/include/small_vectors/detail/uninitialized_constexpr.h
+++ b/include/small_vectors/detail/uninitialized_constexpr.h
@@ -6,7 +6,7 @@
 #include <cstring>
 #include <algorithm>
 
-namespace small_vectors::inline v3_0::detail
+namespace small_vectors::inline v3_2::detail
   {
 // By default, only trivially copyable or trivially movable types are relocatable
 // however, is_relocatable may be specialized to mark complex types as relocatable
@@ -450,5 +450,5 @@ inline constexpr void uninitialized_uneven_range_swap(
   uninitialized_relocate_if_noexcept_n(iter2 + size1, size_type(size2 - size1), iter1 + size1);
   small_vectors_clang_unsafe_buffer_usage_end  //
   }
-  }  // namespace small_vectors::inline v3_0::detail
+  }  // namespace small_vectors::inline v3_2::detail
 

--- a/include/small_vectors/detail/uninitialized_constexpr.h
+++ b/include/small_vectors/detail/uninitialized_constexpr.h
@@ -1,5 +1,5 @@
 #pragma once
-
+#include <small_vectors/version.h>
 #include <small_vectors/utils/utility_cxx20.h>
 #include <small_vectors/concepts/concepts.h>
 #include <memory>
@@ -112,8 +112,11 @@ inline constexpr void uninitialized_default_construct(
 ) noexcept(std::is_nothrow_constructible_v<iterator_value_type_t<iterator>>)
   {
   if(std::is_constant_evaluated())
-    for(; first != last; ++first)
-      std::construct_at(std::addressof(*first));
+    {
+    small_vectors_clang_unsafe_buffer_usage_begin  //
+      for(; first != last; ++first) std::construct_at(std::addressof(*first));
+    small_vectors_clang_unsafe_buffer_usage_end  //
+    }
   else
     std::uninitialized_default_construct(first, last);
   }
@@ -124,8 +127,11 @@ inline constexpr void uninitialized_value_construct_n(
 ) noexcept(std::is_nothrow_constructible_v<iterator_value_type_t<iterator>>)
   {
   if(std::is_constant_evaluated())
-    for(size_type ix{}; ix != count; ++ix)
-      std::construct_at(std::addressof(first[ix]));
+    {
+    small_vectors_clang_unsafe_buffer_usage_begin  //
+      for(size_type ix{}; ix != count; ++ix) std::construct_at(std::addressof(first[ix]));
+    small_vectors_clang_unsafe_buffer_usage_end  //
+    }
   else
     std::uninitialized_value_construct_n(first, count);
   }
@@ -136,8 +142,11 @@ inline constexpr auto uninitialized_value_construct(
 ) noexcept(std::is_nothrow_constructible_v<iterator_value_type_t<iterator>>)
   {
   if(std::is_constant_evaluated())
-    for(; first != last; ++first)
-      std::construct_at(std::addressof(*first));
+    {
+    small_vectors_clang_unsafe_buffer_usage_begin  //
+      for(; first != last; ++first) std::construct_at(std::addressof(*first));
+    small_vectors_clang_unsafe_buffer_usage_end  //
+    }
   else
     std::uninitialized_value_construct(first, last);
   return last;
@@ -151,9 +160,10 @@ inline constexpr auto uninitialized_fill(
   constexpr bool use_nothrow = std::is_nothrow_constructible_v<iterator_value_type_t<iterator>>;
   using unwind = range_unwinder<use_nothrow, iterator>;
   unwind cur{first};
-  for(; cur.last_ != last; (void)++cur.last_)
-    std::construct_at(std::addressof(*cur.last_), fill_value);
-  cur.release();
+  small_vectors_clang_unsafe_buffer_usage_begin  //
+    for(; cur.last_ != last; (void)++cur.last_) std::construct_at(std::addressof(*cur.last_), fill_value);
+  small_vectors_clang_unsafe_buffer_usage_end  //
+    cur.release();
   return cur.last_;
   }
 
@@ -198,9 +208,10 @@ inline auto uninitialized_copy_n_impl(InputIterator first, Size count, ForwardIt
   constexpr bool use_nothrow = std::is_nothrow_constructible_v<iterator_value_type_t<InputIterator>>;
   using unwind = range_unwinder<use_nothrow, ForwardIterator>;
   unwind cur{result};
-  for(; count > 0; --count, (void)++first, ++cur.last_)
-    std::construct_at(std::addressof(*cur.last_), *first);
-  cur.release();
+  small_vectors_clang_unsafe_buffer_usage_begin  //
+    for(; count > 0; --count, (void)++first, ++cur.last_) std::construct_at(std::addressof(*cur.last_), *first);
+  small_vectors_clang_unsafe_buffer_usage_end  //
+    cur.release();
   return cur.last_;
   }
 
@@ -223,9 +234,10 @@ inline auto uninitialized_copy_impl(InputIterator first, InputIterator last, For
   constexpr bool use_nothrow = std::is_nothrow_constructible_v<iterator_value_type_t<InputIterator>>;
   using unwind = range_unwinder<use_nothrow, ForwardIterator>;
   unwind cur{result};
-  for(; first != last; ++first, (void)++cur.last_)
-    std::construct_at(std::addressof(*cur.last_), *first);
-  cur.release();
+  small_vectors_clang_unsafe_buffer_usage_begin  //
+    for(; first != last; ++first, (void)++cur.last_) std::construct_at(std::addressof(*cur.last_), *first);
+  small_vectors_clang_unsafe_buffer_usage_end  //
+    cur.release();
   return cur.last_;
   }
 
@@ -236,9 +248,10 @@ inline constexpr auto uninitialized_copy(
   {
   if(std::is_constant_evaluated())
     {
-    for(; first != last; ++first, (void)++result)
-      std::construct_at(std::addressof(*result), *first);
-    return result;
+    small_vectors_clang_unsafe_buffer_usage_begin  //
+      for(; first != last; ++first, (void)++result) std::construct_at(std::addressof(*result), *first);
+    small_vectors_clang_unsafe_buffer_usage_end  //
+      return result;
     }
   else
     return uninitialized_copy_impl(first, last, result);
@@ -250,8 +263,11 @@ inline constexpr void uninitialized_copy_n(
 ) noexcept(std::is_nothrow_constructible_v<iterator_value_type_t<InputIterator>>)
   {
   if(std::is_constant_evaluated())
-    for(; count > 0; --count, (void)++first, ++result)
-      std::construct_at(std::addressof(*result), *first);
+    {
+    small_vectors_clang_unsafe_buffer_usage_begin  //
+      for(; count > 0; --count, (void)++first, ++result) std::construct_at(std::addressof(*result), *first);
+    small_vectors_clang_unsafe_buffer_usage_end  //
+    }
   else
     uninitialized_copy_n_impl(first, count, result);
   }
@@ -282,9 +298,10 @@ inline auto uninitialized_move_impl(InputIterator first, InputIterator last, For
   constexpr bool use_nothrow = std::is_nothrow_constructible_v<iterator_value_type_t<InputIterator>>;
   using unwind = range_unwinder<use_nothrow, ForwardIterator>;
   unwind cur{result};
-  for(; first != last; ++first, (void)++cur.last_)
-    std::construct_at(std::addressof(*cur.last_), std::move(*first));
-  cur.release();
+  small_vectors_clang_unsafe_buffer_usage_begin  //
+    for(; first != last; ++first, (void)++cur.last_) std::construct_at(std::addressof(*cur.last_), std::move(*first));
+  small_vectors_clang_unsafe_buffer_usage_end  //
+    cur.release();
   return cur.last_;
   }
 
@@ -307,9 +324,11 @@ auto uninitialized_move_n_impl(InputIterator first, Size count, ForwardIterator 
   constexpr bool use_nothrow = std::is_nothrow_constructible_v<iterator_value_type_t<InputIterator>>;
   using unwind = range_unwinder<use_nothrow, ForwardIterator>;
   unwind cur{result};
-  for(; count > 0; --count, (void)++first, ++cur.last_)
-    std::construct_at(std::addressof(*cur.last_), std::move(*first));
-  cur.release();
+  small_vectors_clang_unsafe_buffer_usage_begin  //
+    for(; count > 0; --count, (void)++first, ++cur.last_)
+      std::construct_at(std::addressof(*cur.last_), std::move(*first));
+  small_vectors_clang_unsafe_buffer_usage_end  //
+    cur.release();
   return cur.last_;
   }
 
@@ -331,8 +350,11 @@ inline constexpr void uninitialized_move_n(
 ) noexcept(std::is_nothrow_move_constructible_v<iterator_value_type_t<InputIterator>>)
   {
   if(std::is_constant_evaluated())
-    for(; count > 0; --count, (void)++first, ++result)
-      std::construct_at(std::addressof(*result), std::move(*first));
+    {
+    small_vectors_clang_unsafe_buffer_usage_begin  //
+      for(; count > 0; --count, (void)++first, ++result) std::construct_at(std::addressof(*result), std::move(*first));
+    small_vectors_clang_unsafe_buffer_usage_end  //
+    }
   else
     uninitialized_move_n_impl(first, count, result);
   }
@@ -423,8 +445,10 @@ inline constexpr void uninitialized_uneven_range_swap(
     std::swap(iter1, iter2);
     std::swap(size1, size2);
     }
-  std::swap_ranges(iter1, iter1 + size1, iter2);
+  small_vectors_clang_unsafe_buffer_usage_begin  //
+    std::swap_ranges(iter1, iter1 + size1, iter2);
   uninitialized_relocate_if_noexcept_n(iter2 + size1, size_type(size2 - size1), iter1 + size1);
+  small_vectors_clang_unsafe_buffer_usage_end  //
   }
-
   }  // namespace small_vectors::inline v3_0::detail
+

--- a/include/small_vectors/detail/vector_func.h
+++ b/include/small_vectors/detail/vector_func.h
@@ -7,7 +7,7 @@
 #include <stdexcept>
 #include <cassert>
 
-namespace small_vectors::inline v3_0::detail
+namespace small_vectors::inline v3_2::detail
   {
 
 enum struct vector_outcome_e : uint8_t
@@ -1033,5 +1033,5 @@ constexpr vector_outcome_e shrink_to_fit(vector_type & vec
     }
   return vector_outcome_e::no_error;
   }
-  }  // namespace small_vectors::inline v3_0::detail
+  }  // namespace small_vectors::inline v3_2::detail
 

--- a/include/small_vectors/detail/vector_func.h
+++ b/include/small_vectors/detail/vector_func.h
@@ -5,6 +5,7 @@
 #include <small_vectors/utils/enum_support.h>
 #include <memory>
 #include <stdexcept>
+#include <cassert>
 
 namespace small_vectors::inline v3_0::detail
   {

--- a/include/small_vectors/detail/vector_storage.h
+++ b/include/small_vectors/detail/vector_storage.h
@@ -4,7 +4,7 @@
 #include <utility>
 #include <array>
 
-namespace small_vectors::inline v3_0::detail
+namespace small_vectors::inline v3_2::detail
   {
 
 template<typename value_type, std::unsigned_integral size_type>
@@ -844,8 +844,8 @@ struct small_vector_storage
     return result;
     }
 
-  inline constexpr auto
-    exchange_priv_(storage_context_type new_storage, size_type size) noexcept -> storage_context_type
+  inline constexpr auto exchange_priv_(storage_context_type new_storage, size_type size) noexcept
+    -> storage_context_type
     {
     if(active_ == dynamic)
       {
@@ -1019,8 +1019,8 @@ struct small_vector_storage<V, S, 0u>
       }
     }
 
-  inline constexpr auto
-    exchange_priv_(storage_context_type new_storage, size_type size) noexcept -> storage_context_type
+  inline constexpr auto exchange_priv_(storage_context_type new_storage, size_type size) noexcept
+    -> storage_context_type
     {
     size_ = size;
     return std::exchange(dynamic, new_storage);
@@ -1029,5 +1029,5 @@ struct small_vector_storage<V, S, 0u>
   inline constexpr void set_size_priv_(size_type pos_ix) noexcept { size_ = pos_ix; }
   };
 
-  }  // namespace small_vectors::inline v3_0::detail
+  }  // namespace small_vectors::inline v3_2::detail
 

--- a/include/small_vectors/formattable/basic_fixed_string.h
+++ b/include/small_vectors/formattable/basic_fixed_string.h
@@ -8,7 +8,7 @@
 namespace std
   {
 template<typename CharType, std::size_t N>
-struct formatter<small_vectors::v3_0::basic_fixed_string<CharType, N>, CharType>
+struct formatter<small_vectors::basic_fixed_string<CharType, N>, CharType>
   {
   formatter<std::basic_string_view<CharType>, CharType> value_formatter;
 
@@ -20,7 +20,7 @@ struct formatter<small_vectors::v3_0::basic_fixed_string<CharType, N>, CharType>
 
   template<typename FormatContext>
   [[nodiscard]]
-  auto format(small_vectors::v3_0::basic_fixed_string<CharType, N> const & value, FormatContext & ctx) const ->
+  auto format(small_vectors::basic_fixed_string<CharType, N> const & value, FormatContext & ctx) const ->
     typename FormatContext::iterator
     {
     return value_formatter.format(value.view(), ctx);

--- a/include/small_vectors/formattable/basic_string.h
+++ b/include/small_vectors/formattable/basic_string.h
@@ -7,7 +7,7 @@
 
 template<typename char_type, uint64_t N, typename T>
   requires std::formattable<std::basic_string_view<char_type>, char_type>
-struct std::formatter<small_vectors::v3_0::basic_string_t<char_type, N, T>, char_type>
+struct std::formatter<small_vectors::basic_string_t<char_type, N, T>, char_type>
   {
   std::formatter<std::basic_string_view<char_type>, char_type> value_formatter;
 
@@ -19,7 +19,7 @@ struct std::formatter<small_vectors::v3_0::basic_string_t<char_type, N, T>, char
 
   template<typename FormatContext>
   [[nodiscard]]
-  auto format(small_vectors::v3_0::basic_string_t<char_type, N, T> const & value, FormatContext & ctx) const ->
+  auto format(small_vectors::basic_string_t<char_type, N, T> const & value, FormatContext & ctx) const ->
     typename FormatContext::iterator
     {
     std::basic_string_view<char_type> view(value);

--- a/include/small_vectors/formattable/strong_type.h
+++ b/include/small_vectors/formattable/strong_type.h
@@ -5,10 +5,6 @@
 #include <small_vectors/utils/strong_type.h>
 #include <format>
 
-namespace small_vectors::inline v3_0::utils
-  {
-  }
-
 template<typename value_type, typename tag>
 struct std::formatter<small_vectors::utils::strong_type<value_type, tag>>
   {

--- a/include/small_vectors/inclass_storage.h
+++ b/include/small_vectors/inclass_storage.h
@@ -11,7 +11,7 @@
 #include <concepts>
 #include <type_traits>
 
-namespace small_vectors::inline v3_0
+namespace small_vectors::inline v3_2
   {
 namespace concepts
   {
@@ -263,4 +263,4 @@ public:
   constexpr auto operator->() const noexcept -> value_type const * { return ptr(); }
   };
 
-  }  // namespace small_vectors::inline v3_0
+  }  // namespace small_vectors::inline v3_2

--- a/include/small_vectors/interprocess/atomic_mutex.h
+++ b/include/small_vectors/interprocess/atomic_mutex.h
@@ -3,7 +3,7 @@
 #include <atomic>
 #include <thread>
 
-namespace small_vectors::inline v3_0::ip
+namespace small_vectors::inline v3_2::ip
   {
 /* NOTE
 memory_order_seq_cst - is used intentionaly, as read operations after store within mutex have to observe results by all
@@ -62,4 +62,4 @@ struct atomic_mutex
     state_.compare_exchange_strong(expected, false, std::memory_order_seq_cst);
     }
   };
-  }  // namespace small_vectors::inline v3_0::ip
+  }  // namespace small_vectors::inline v3_2::ip

--- a/include/small_vectors/interprocess/fork.h
+++ b/include/small_vectors/interprocess/fork.h
@@ -7,7 +7,7 @@
 #include <sys/unistd.h>
 #include <sys/wait.h>
 
-namespace small_vectors::inline v3_0::ip
+namespace small_vectors::inline v3_2::ip
   {
 struct fork_child_t
   {
@@ -55,4 +55,4 @@ inline auto fork(function const & fn, Args... args) noexcept -> std::optional<fo
   else
     return {};
   }
-  }  // namespace small_vectors::inline v3_0::ip
+  }  // namespace small_vectors::inline v3_2::ip

--- a/include/small_vectors/interprocess/ring_queue.h
+++ b/include/small_vectors/interprocess/ring_queue.h
@@ -8,7 +8,7 @@
 #include <ranges>
 #include <algorithm>
 
-namespace small_vectors::inline v3_0::ip
+namespace small_vectors::inline v3_2::ip
   {
 namespace detail
   {
@@ -116,4 +116,4 @@ namespace detail
       }
     };
   }  // namespace detail
-  }  // namespace small_vectors::inline v3_0::ip
+  }  // namespace small_vectors::inline v3_2::ip

--- a/include/small_vectors/interprocess/shared_mem_utils.h
+++ b/include/small_vectors/interprocess/shared_mem_utils.h
@@ -4,7 +4,7 @@
 #include <concepts>
 #include <cstdint>
 
-namespace small_vectors::inline v3_0::ip
+namespace small_vectors::inline v3_2::ip
   {
 namespace detail
   {
@@ -50,9 +50,7 @@ namespace detail
   template<typename type>
   concept concept_mapped_region = requires(type & region) {
     region.get_address();
-      {
-      region.get_address()
-      } -> concept_pointer;
+      { region.get_address() } -> concept_pointer;
   };
   }  // namespace detail
 
@@ -76,4 +74,4 @@ inline auto ref(detail::concept_mapped_region auto & region) noexcept -> typenam
   return *std::launder(reinterpret_cast<type *>(addr));
   }
 
-  }  // namespace small_vectors::inline v3_0::ip
+  }  // namespace small_vectors::inline v3_2::ip

--- a/include/small_vectors/interprocess/stack_buffer.h
+++ b/include/small_vectors/interprocess/stack_buffer.h
@@ -102,8 +102,8 @@ struct empty_t
   {
   template<std::size_t buffer_size, typename index_type>
   [[nodiscard]]
-  small_vector_static_call_operator constexpr auto
-    operator()(stack_buffer_t<buffer_size, index_type> const & buff) small_vector_static_call_operator_const noexcept
+  small_vector_static_call_operator constexpr auto operator()(stack_buffer_t<buffer_size, index_type> const & buff
+  ) small_vector_static_call_operator_const noexcept
     {
     auto const b = buff.stack_index_.load(acquire);
     return b.index == 0;
@@ -131,9 +131,9 @@ struct push_t
   {
   template<std::size_t buffer_size, typename index_type, std::forward_iterator iterator>
   [[nodiscard]]
-  small_vector_static_call_operator constexpr auto
-    operator()(stack_buffer_t<buffer_size, index_type> & buff, iterator data_beg, iterator data_end)
-      small_vector_static_call_operator_const noexcept -> push_status
+  small_vector_static_call_operator constexpr auto operator()(
+    stack_buffer_t<buffer_size, index_type> & buff, iterator data_beg, iterator data_end
+  ) small_vector_static_call_operator_const noexcept -> push_status
     {
     // calculate space required
     stack_index_t stack_index{buff.stack_index_.load(acquire)};
@@ -185,10 +185,16 @@ struct top_t
     if(stack_during_copy_top.index != 0) [[likely]]
       {
       auto [footer, it_top_footer]{detail::footer_from_index(buff, stack_during_copy_top)};
+#ifdef __clang__
+#pragma clang unsafe_buffer_usage begin
+#endif
       return std::make_pair(
         std::span<uint8_t const>{ranges::prev(it_top_footer, static_cast<ptrdiff_t>(footer.size)), it_top_footer},
         stack_during_copy_top
       );
+#ifdef __clang__
+#pragma clang unsafe_buffer_usage end
+#endif
       }
     return {};
     }
@@ -200,9 +206,9 @@ struct pop_t
   {
   template<std::size_t buffer_size, typename index_type>
   [[nodiscard]]
-  small_vector_static_call_operator constexpr pop_status
-    operator()(stack_buffer_t<buffer_size, index_type> & buff, stack_index_t stack_during_copy_top)
-      small_vector_static_call_operator_const noexcept
+  small_vector_static_call_operator constexpr pop_status operator()(
+    stack_buffer_t<buffer_size, index_type> & buff, stack_index_t stack_during_copy_top
+  ) small_vector_static_call_operator_const noexcept
     {
     auto [footer, _]{detail::footer_from_index(buff, stack_during_copy_top)};
     stack_index_t next_index{stack_during_copy_top.index - footer.size - sizeof(footer_data_t)};
@@ -214,4 +220,4 @@ struct pop_t
   };
 
 inline constexpr pop_t pop;
-  }  // namespace ip
+  }  // namespace small_vectors::inline v3_0::ip

--- a/include/small_vectors/interprocess/stack_buffer.h
+++ b/include/small_vectors/interprocess/stack_buffer.h
@@ -9,7 +9,7 @@
 #include <algorithm>
 #include <bit>
 
-namespace small_vectors::inline v3_0::ip
+namespace small_vectors::inline v3_2::ip
   {
 enum struct push_status : uint8_t
   {
@@ -220,4 +220,4 @@ struct pop_t
   };
 
 inline constexpr pop_t pop;
-  }  // namespace small_vectors::inline v3_0::ip
+  }  // namespace small_vectors::inline v3_2::ip

--- a/include/small_vectors/ranges/accumulate.h
+++ b/include/small_vectors/ranges/accumulate.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <small_vectors/utils/static_call_operator.h>
+#include <small_vectors/version.h>
 #include <concepts>
 #include <iterator>
 #include <ranges>
@@ -10,19 +11,20 @@ struct accumulate_t
   {
   template<std::input_iterator source_iterator, std::sentinel_for<source_iterator> sentinel>
   [[nodiscard]]
-  small_vector_static_call_operator constexpr auto
-    operator()(source_iterator beg, sentinel end, auto init, auto binary_op)
-      small_vector_static_call_operator_const noexcept
+  small_vector_static_call_operator constexpr auto operator()(
+    source_iterator beg, sentinel end, auto init, auto binary_op
+  ) small_vector_static_call_operator_const noexcept
     {
-    for(; beg != end; ++beg)
-      init = binary_op(std::move(init), *beg);
-    return init;
+    small_vectors_clang_unsafe_buffer_usage_begin  //
+      for(; beg != end; ++beg) init
+      = binary_op(std::move(init), *beg);
+    small_vectors_clang_unsafe_buffer_usage_end  //
+      return init;
     }
 
   template<std::input_iterator source_iterator, std::sentinel_for<source_iterator> sentinel>
   [[nodiscard]]
-  small_vector_static_call_operator constexpr auto
-    operator()(source_iterator beg, sentinel end, auto init)
+  small_vector_static_call_operator constexpr auto operator()(source_iterator beg, sentinel end, auto init)
     {
     return operator()(beg, end, std::move(init), std::plus<decltype(init)>{});
     }
@@ -45,4 +47,4 @@ struct accumulate_t
   };
 
 inline constexpr accumulate_t accumulate;
-  }  // namespace coll::ranges
+  }  // namespace small_vectors::inline v3_0::ranges

--- a/include/small_vectors/ranges/accumulate.h
+++ b/include/small_vectors/ranges/accumulate.h
@@ -5,7 +5,7 @@
 #include <iterator>
 #include <ranges>
 
-namespace small_vectors::inline v3_0::ranges
+namespace small_vectors::inline v3_2::ranges
   {
 struct accumulate_t
   {
@@ -47,4 +47,4 @@ struct accumulate_t
   };
 
 inline constexpr accumulate_t accumulate;
-  }  // namespace small_vectors::inline v3_0::ranges
+  }  // namespace small_vectors::inline v3_2::ranges

--- a/include/small_vectors/safe_buffers_error_handler.h
+++ b/include/small_vectors/safe_buffers_error_handler.h
@@ -1,0 +1,8 @@
+#pragma once
+#include <functional>
+#include <string_view>
+
+namespace small_vectors::inline v3_0
+  {
+auto set_error_report_handler(std::function<void(std::string_view)>) -> void;
+  }

--- a/include/small_vectors/safe_buffers_error_handler.h
+++ b/include/small_vectors/safe_buffers_error_handler.h
@@ -2,7 +2,7 @@
 #include <functional>
 #include <string_view>
 
-namespace small_vectors::inline v3_0
+namespace small_vectors::inline v3_2
   {
 auto set_error_report_handler(std::function<void(std::string_view)>) -> void;
   }

--- a/include/small_vectors/small_vector.h
+++ b/include/small_vectors/small_vector.h
@@ -27,13 +27,13 @@
 #include <span>
 #include <cassert>
 
-namespace small_vectors::inline v3_0::detail
+namespace small_vectors::inline v3_2::detail
   {
 template<typename value_type, typename size_type>
 inline constexpr void sv_deallocate(value_type * p, size_type count) noexcept;
-  }  // namespace small_vectors::inline v3_0::detail
+  }  // namespace small_vectors::inline v3_2::detail
 
-namespace small_vectors::inline v3_0
+namespace small_vectors::inline v3_2
   {
 using detail::vector_outcome_e;
 
@@ -566,4 +566,4 @@ inline constexpr auto shrink_to_fit(small_vector<V, S, N> & vec) -> vector_outco
   {
   return vec.shrink_to_fit();
   }
-  }  // namespace small_vectors::inline v3_0
+  }  // namespace small_vectors::inline v3_2

--- a/include/small_vectors/small_vector.h
+++ b/include/small_vectors/small_vector.h
@@ -18,14 +18,14 @@
 // DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-#include <cassert>
-
+#include <small_vectors/detail/safe_buffers.h>
 #include <small_vectors/detail/uninitialized_constexpr.h>
 #include <small_vectors/detail/vector_storage.h>
 #include <small_vectors/detail/vector_func.h>
 #include <small_vectors/detail/adapter_iterator.h>
 
 #include <span>
+#include <cassert>
 
 namespace small_vectors::inline v3_0::detail
   {
@@ -178,7 +178,14 @@ struct small_vector
   inline constexpr auto operator[](arg_size_type index) const noexcept -> value_type const &
     {
     assert(index < size());
-    return data()[index];
+    if constexpr(detail::check_valid_element_access)
+      {
+      if(storage_.size_ <= index) [[unlikely]]
+        detail::report_invalid_element_access("out of bounds element access ", storage_.size_, index);
+      }
+    small_vectors_clang_unsafe_buffer_usage_begin  //
+      return data()[index];
+    small_vectors_clang_unsafe_buffer_usage_end  //
     }
 
   template<concepts::unsigned_arithmetic_integral arg_size_type>
@@ -186,7 +193,14 @@ struct small_vector
   inline constexpr auto operator[](arg_size_type index) noexcept -> value_type &
     {
     assert(index < size());
-    return data()[index];
+    if constexpr(detail::check_valid_element_access)
+      {
+      if(storage_.size_ <= index) [[unlikely]]
+        detail::report_invalid_element_access("out of bounds element access ", storage_.size_, index);
+      }
+    small_vectors_clang_unsafe_buffer_usage_begin  //
+      return data()[index];
+    small_vectors_clang_unsafe_buffer_usage_end  //
     }
 
   template<concepts::unsigned_arithmetic_integral arg_size_type>
@@ -194,7 +208,14 @@ struct small_vector
   inline constexpr auto at(arg_size_type index) const noexcept -> value_type const &
     {
     assert(index < size());
-    return data()[index];
+    if constexpr(detail::check_valid_element_access)
+      {
+      if(storage_.size_ <= index) [[unlikely]]
+        detail::report_invalid_element_access("out of bounds element access ", storage_.size_, index);
+      }
+    small_vectors_clang_unsafe_buffer_usage_begin  //
+      return data()[index];
+    small_vectors_clang_unsafe_buffer_usage_end  //
     }
 
   template<concepts::unsigned_arithmetic_integral arg_size_type>
@@ -202,7 +223,14 @@ struct small_vector
   inline constexpr auto at(arg_size_type index) noexcept -> value_type &
     {
     assert(index < size());
-    return data()[index];
+    if constexpr(detail::check_valid_element_access)
+      {
+      if(storage_.size_ <= index) [[unlikely]]
+        detail::report_invalid_element_access("out of bounds element access ", storage_.size_, index);
+      }
+    small_vectors_clang_unsafe_buffer_usage_begin  //
+      return data()[index];
+    small_vectors_clang_unsafe_buffer_usage_end  //
     }
 
   // compatibility with old code

--- a/include/small_vectors/static_vector.h
+++ b/include/small_vectors/static_vector.h
@@ -26,7 +26,7 @@
 #include <small_vectors/detail/vector_func.h>
 #include <small_vectors/detail/adapter_iterator.h>
 
-namespace small_vectors::inline v3_0
+namespace small_vectors::inline v3_2
   {
 using detail::vector_outcome_e;
 using detail::vector_tune_e;
@@ -517,4 +517,4 @@ inline constexpr vector_outcome_e split_by_half(
   else
     return vector_outcome_e::out_of_storage;
   }
-  }  // namespace small_vectors::inline v3_0
+  }  // namespace small_vectors::inline v3_2

--- a/include/small_vectors/stream/basic_fixed_string.h
+++ b/include/small_vectors/stream/basic_fixed_string.h
@@ -5,7 +5,7 @@
 #include <small_vectors/basic_fixed_string.h>
 #include <iostream>
 
-namespace small_vectors::inline v3_0
+namespace small_vectors::inline v3_2
   {
 template<concepts::integral_or_byte CharType, std::size_t N>
 std::basic_ostream<CharType> &
@@ -15,4 +15,4 @@ std::basic_ostream<CharType> &
   os << str.view();
   return os;
   }
-  }  // namespace small_vectors::inline v3_0
+  }  // namespace small_vectors::inline v3_2

--- a/include/small_vectors/stream/basic_string.h
+++ b/include/small_vectors/stream/basic_string.h
@@ -5,7 +5,7 @@
 #include <small_vectors/basic_string.h>
 #include <iostream>
 
-namespace small_vectors::inline v3_0
+namespace small_vectors::inline v3_2
   {
 template<typename char_type, uint64_t N, typename T>
 std::ostream & operator<<(std::ostream & os, basic_string_t<char_type, N, T> const & str)
@@ -14,4 +14,4 @@ std::ostream & operator<<(std::ostream & os, basic_string_t<char_type, N, T> con
   os << view;
   return os;
   }
-  }  // namespace small_vectors::inline v3_0
+  }  // namespace small_vectors::inline v3_2

--- a/include/small_vectors/stream/strong_type.h
+++ b/include/small_vectors/stream/strong_type.h
@@ -6,7 +6,7 @@
 #include <small_vectors/concepts/stream_insertable.h>
 #include <iostream>
 
-namespace small_vectors::inline v3_0::utils
+namespace small_vectors::inline v3_2::utils
   {
 
 template<small_vectors::concepts::stream_insertable ValueType, typename Tag>
@@ -16,4 +16,4 @@ std::ostream & operator<<(std::ostream & os, strong_type<ValueType, Tag> const &
   return os;
   }
 
-  }  // namespace small_vectors::inline v3_0::utils
+  }  // namespace small_vectors::inline v3_2::utils

--- a/include/small_vectors/utils/endian.h
+++ b/include/small_vectors/utils/endian.h
@@ -5,7 +5,7 @@
 #include <cstdint>
 #include <algorithm>
 
-namespace small_vectors::inline v3_0::utils
+namespace small_vectors::inline v3_2::utils
   {
 #if defined(__cpp_lib_endian)
 using std::endian;
@@ -24,4 +24,4 @@ enum struct endian
   };
 #endif
 
-  }  // namespace small_vectors::inline v3_0::utils
+  }  // namespace small_vectors::inline v3_2::utils

--- a/include/small_vectors/utils/enum_support.h
+++ b/include/small_vectors/utils/enum_support.h
@@ -6,7 +6,7 @@
 #include <type_traits>
 #include <string_view>
 
-namespace small_vectors::inline v3_0::utils
+namespace small_vectors::inline v3_2::utils
   {
 namespace internal
   {
@@ -41,4 +41,4 @@ inline constexpr enum_type enum_cond_flag(bool cond, enum_type cond_e) noexcept
   else
     return {};
   }
-  }  // namespace small_vectors::inline v3_0::utils
+  }  // namespace small_vectors::inline v3_2::utils

--- a/include/small_vectors/utils/meta_packed_struct.h
+++ b/include/small_vectors/utils/meta_packed_struct.h
@@ -8,7 +8,7 @@
 #include <cassert>
 #include <concepts>
 
-namespace small_vectors::inline v3_0::utils
+namespace small_vectors::inline v3_2::utils
   {
 
 namespace detail
@@ -309,4 +309,4 @@ constexpr decltype(auto) get(meta_packed_struct && s)
   return detail::get<tag_value>(std::forward<meta_packed_struct>(s));
   }
 
-  }  // namespace small_vectors::inline v3_0::utils
+  }  // namespace small_vectors::inline v3_2::utils

--- a/include/small_vectors/utils/strong_function.h
+++ b/include/small_vectors/utils/strong_function.h
@@ -2,7 +2,7 @@
 #include <functional>
 #include <type_traits>
 
-namespace small_vectors::inline v3_0::utils
+namespace small_vectors::inline v3_2::utils
   {
 template<typename Tag, typename X>
 struct strong_function;  // undefined
@@ -30,4 +30,4 @@ struct strong_function<Tag, ret_type(args_type...)>
 template<typename Tag, class ret_type, class... args_type>
 strong_function(Tag, ret_type (*)(args_type...)) -> strong_function<Tag, ret_type(args_type...)>;
 
-  }  // namespace small_vectors::inline v3_0::utils
+  }  // namespace small_vectors::inline v3_2::utils

--- a/include/small_vectors/utils/strong_type.h
+++ b/include/small_vectors/utils/strong_type.h
@@ -31,7 +31,7 @@
 #include <compare>
 #include <cstdint>
 
-namespace small_vectors::inline v3_0::utils
+namespace small_vectors::inline v3_2::utils
   {
 
 struct strong_type_default_traits
@@ -103,7 +103,7 @@ namespace concepts
     requires tag::enable_hash_specialization == true;
   };
   }  // namespace concepts
-  }  // namespace small_vectors::inline v3_0
+  }  // namespace small_vectors::inline v3_2::utils
 
 template<small_vectors::concepts::hashable value_type, small_vectors::utils::concepts::tag_hash_specialization tag>
 struct std::hash<small_vectors::utils::strong_type<value_type, tag>>
@@ -112,8 +112,7 @@ struct std::hash<small_vectors::utils::strong_type<value_type, tag>>
 #if defined(__cpp_static_call_operator)
   static
 #endif
-    constexpr auto
-    operator()(small_vectors::utils::strong_type<value_type, tag> t)
+    constexpr auto operator()(small_vectors::utils::strong_type<value_type, tag> t)
 #if !defined(__cpp_static_call_operator)
       const
 #endif
@@ -123,16 +122,16 @@ struct std::hash<small_vectors::utils::strong_type<value_type, tag>>
     }
   };
 
-namespace small_vectors::inline v3_0::concepts
+namespace small_vectors::inline v3_2::concepts
   {
 template<typename tag>
 concept tag_ostream = requires {
   tag::enable_ostream;
   requires tag::enable_ostream == true;
 };
-  }  // namespace small_vectors::inline v3_0::concepts
+  }  // namespace small_vectors::inline v3_2::concepts
 
-namespace small_vectors::inline v3_0::utils
+namespace small_vectors::inline v3_2::utils
   {
 template<small_vectors::concepts::stream_insertable value_type, small_vectors::concepts::tag_ostream tag>
 inline auto operator<<(std::ostream & out, strong_type<value_type, tag> const & value) -> std::ostream &
@@ -153,7 +152,7 @@ namespace concepts
     tag::enable_arithemtic;
     requires tag::enable_arithemtic == true;
   };
-  }
+  }  // namespace concepts
 
 template<small_vectors::concepts::prefix_incrementable value_type, concepts::tag_arithemtic tag>
 constexpr auto operator++(strong_type<value_type, tag> & v) noexcept -> strong_type<value_type, tag> &
@@ -197,7 +196,7 @@ namespace concepts
     tag::enable_comparison;
     requires tag::enable_comparison == true;
   };
-  }
+  }  // namespace concepts
 
 template<std::equality_comparable value_type, concepts::tag_comparison tag>
 [[nodiscard]]
@@ -257,8 +256,8 @@ inline constexpr auto
 
 template<small_vectors::concepts::multiplicatable_with<int> value_type, concepts::tag_arithemtic tag>
 [[nodiscard]]
-inline constexpr auto
-  operator*(strong_type<value_type, tag> const & lhs, int rhs) noexcept -> strong_type<value_type, tag>
+inline constexpr auto operator*(strong_type<value_type, tag> const & lhs, int rhs) noexcept
+  -> strong_type<value_type, tag>
   {
   return strong_type<value_type, tag>{static_cast<value_type>(lhs.value() * rhs)};
   }
@@ -274,8 +273,8 @@ inline constexpr auto
 
 template<small_vectors::concepts::dividable value_type, concepts::tag_arithemtic tag>
 [[nodiscard]]
-inline constexpr auto
-  operator/(strong_type<value_type, tag> const & lhs, unsigned rhs) noexcept -> strong_type<value_type, tag>
+inline constexpr auto operator/(strong_type<value_type, tag> const & lhs, unsigned rhs) noexcept
+  -> strong_type<value_type, tag>
   {
   return strong_type<value_type, tag>{static_cast<value_type>(lhs.value() / static_cast<value_type>(rhs))};
   }
@@ -291,8 +290,8 @@ inline constexpr auto
 
 template<small_vectors::concepts::has_modulo_operator value_type, concepts::tag_arithemtic tag>
 [[nodiscard]]
-inline constexpr auto
-  operator%(strong_type<value_type, tag> const & lhs, unsigned rhs) noexcept -> strong_type<value_type, tag>
+inline constexpr auto operator%(strong_type<value_type, tag> const & lhs, unsigned rhs) noexcept
+  -> strong_type<value_type, tag>
   {
   return strong_type<value_type, tag>{static_cast<value_type>(lhs.value() % static_cast<value_type>(rhs))};
   }
@@ -309,7 +308,7 @@ namespace concepts
     tag::enable_binary_operators;
     requires tag::enable_binary_operators == true;
   };
-  }
+  }  // namespace concepts
 
 template<small_vectors::concepts::has_bitwise_xor_operator value_type, concepts::tag_binary_operators tag>
 [[nodiscard]]
@@ -322,8 +321,7 @@ inline constexpr auto
 
 template<small_vectors::concepts::has_bitwise_not_operator value_type, concepts::tag_binary_operators tag>
 [[nodiscard]]
-inline constexpr auto
-  operator~(strong_type<value_type, tag> const & v) noexcept -> strong_type<value_type, tag>
+inline constexpr auto operator~(strong_type<value_type, tag> const & v) noexcept -> strong_type<value_type, tag>
   {
   return strong_type<value_type, tag>{static_cast<value_type>(~v.value())};
   }
@@ -340,8 +338,8 @@ inline constexpr auto
 template<typename value_type, typename operand, concepts::tag_binary_operators tag>
   requires small_vectors::concepts::has_left_shift_operator_with_integral<value_type, operand>
 [[nodiscard]]
-inline constexpr auto
-  operator<<(strong_type<value_type, tag> const & lhs, operand rhs) noexcept -> strong_type<value_type, tag>
+inline constexpr auto operator<<(strong_type<value_type, tag> const & lhs, operand rhs) noexcept
+  -> strong_type<value_type, tag>
   {
   return strong_type<value_type, tag>{static_cast<value_type>(lhs.value() << rhs)};
   }
@@ -358,8 +356,8 @@ inline constexpr auto
 template<typename value_type, typename operand, concepts::tag_binary_operators tag>
   requires small_vectors::concepts::has_right_shift_operator_with_integral<value_type, operand>
 [[nodiscard]]
-inline constexpr auto
-  operator>>(strong_type<value_type, tag> const & lhs, operand rhs) noexcept -> strong_type<value_type, tag>
+inline constexpr auto operator>>(strong_type<value_type, tag> const & lhs, operand rhs) noexcept
+  -> strong_type<value_type, tag>
   {
   return strong_type<value_type, tag>{static_cast<value_type>(lhs.value() >> rhs)};
   }
@@ -373,10 +371,12 @@ inline constexpr auto
   return strong_type<value_type, tag>{static_cast<value_type>(lhs.value() & rhs.value())};
   }
 
-template<small_vectors::concepts::has_bitwise_and_operator_with<unsigned> value_type, concepts::tag_binary_operators tag>
+template<
+  small_vectors::concepts::has_bitwise_and_operator_with<unsigned> value_type,
+  concepts::tag_binary_operators tag>
 [[nodiscard]]
-inline constexpr auto
-  operator&(strong_type<value_type, tag> const & lhs, uint16_t rhs) noexcept -> strong_type<value_type, tag>
+inline constexpr auto operator&(strong_type<value_type, tag> const & lhs, uint16_t rhs) noexcept
+  -> strong_type<value_type, tag>
   {
   return strong_type<value_type, tag>{static_cast<value_type>(lhs.value() & rhs)};
   }
@@ -480,6 +480,6 @@ constexpr auto operator|=(strong_type<value_type, tag> & v, strong_type<value_ty
   v.ref_value() |= rhs.value();
   return v;
   }
-  }  // namespace small_vectors::inline v3_0
+  }  // namespace small_vectors::inline v3_2::utils
 
 //

--- a/include/small_vectors/utils/unaligned.h
+++ b/include/small_vectors/utils/unaligned.h
@@ -15,7 +15,7 @@
 // Functions
 //
 // -----------------------------------------------------------------------
-namespace small_vectors::inline v3_0::memutil
+namespace small_vectors::inline v3_2::memutil
   {
 namespace detail
   {
@@ -201,4 +201,4 @@ inline void * void_ptr_cast(input_type data) noexcept
   {
   return reinterpret_cast<void *>(static_cast<uintptr_t>(data));
   }
-  }  // namespace memutil
+  }  // namespace small_vectors::inline v3_2::memutil

--- a/include/small_vectors/version.h
+++ b/include/small_vectors/version.h
@@ -1,3 +1,9 @@
 #pragma once
 
 #define SMALL_VECTORS_VERSION "3.1.8"
+
+#ifdef __clang__
+#define small_vectors_clang_do_pragma(x) _Pragma(#x)
+#define small_vectors_clang_unsafe_buffer_usage_begin small_vectors_clang_do_pragma(clang unsafe_buffer_usage begin)
+#define small_vectors_clang_unsafe_buffer_usage_end small_vectors_clang_do_pragma(clang unsafe_buffer_usage end)
+#endif

--- a/include/small_vectors/version.h
+++ b/include/small_vectors/version.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#define SMALL_VECTORS_VERSION "3.1.8"
+#define SMALL_VECTORS_VERSION "3.2.0"
 
 #ifdef __clang__
 #define small_vectors_clang_do_pragma(x) _Pragma(#x)

--- a/include/small_vectors/version.h
+++ b/include/small_vectors/version.h
@@ -6,4 +6,7 @@
 #define small_vectors_clang_do_pragma(x) _Pragma(#x)
 #define small_vectors_clang_unsafe_buffer_usage_begin small_vectors_clang_do_pragma(clang unsafe_buffer_usage begin)
 #define small_vectors_clang_unsafe_buffer_usage_end small_vectors_clang_do_pragma(clang unsafe_buffer_usage end)
+#else
+#define small_vectors_clang_unsafe_buffer_usage_begin
+#define small_vectors_clang_unsafe_buffer_usage_end
 #endif

--- a/source/safe_buffers.cc
+++ b/source/safe_buffers.cc
@@ -1,0 +1,30 @@
+#include <small_vectors/detail/safe_buffers.h>
+#include <small_vectors/formattable/source_location.h>
+#include <small_vectors/safe_buffers_error_handler.h>
+#include <cstdlib>
+#include <print>
+
+namespace small_vectors::inline v3_0
+  {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wexit-time-destructors"
+#pragma clang diagnostic ignored "-Wglobal-constructors"
+static std::function<void(std::string_view)> error_handler = [](std::string_view error) { std::print("{}", error); };
+#pragma clang diagnostic pop
+
+auto set_error_report_handler(std::function<void(std::string_view)> handler) -> void
+  {
+  error_handler = std::move(handler);
+  }
+  }  // namespace small_vectors::inline v3_0
+
+namespace small_vectors::inline v3_0::detail
+  {
+void report_invalid_element_access(std::string_view, std::size_t size, std::size_t index, std::source_location loc)
+  {
+  std::invoke(
+    error_handler, std::format("[invalid_element_access] current size:{} index:{} called from {}", size, index, loc)
+  );
+  std::abort();
+  }
+  }  // namespace small_vectors::inline v3_0::detail

--- a/source/safe_buffers.cc
+++ b/source/safe_buffers.cc
@@ -4,7 +4,7 @@
 #include <cstdlib>
 #include <print>
 
-namespace small_vectors::inline v3_0
+namespace small_vectors::inline v3_2
   {
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wexit-time-destructors"
@@ -16,9 +16,9 @@ auto set_error_report_handler(std::function<void(std::string_view)> handler) -> 
   {
   error_handler = std::move(handler);
   }
-  }  // namespace small_vectors::inline v3_0
+  }  // namespace small_vectors::inline v3_2
 
-namespace small_vectors::inline v3_0::detail
+namespace small_vectors::inline v3_2::detail
   {
 void report_invalid_element_access(std::string_view, std::size_t size, std::size_t index, std::source_location loc)
   {
@@ -27,4 +27,4 @@ void report_invalid_element_access(std::string_view, std::size_t size, std::size
   );
   std::abort();
   }
-  }  // namespace small_vectors::inline v3_0::detail
+  }  // namespace small_vectors::inline v3_2::detail

--- a/unit_tests/CMakeLists.txt
+++ b/unit_tests/CMakeLists.txt
@@ -29,6 +29,7 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
       -Wno-misleading-indentation
       -Wno-attributes
       -Wno-unused-parameter
+      -Wno-unknown-pragmas
       )
 endif()
 

--- a/unit_tests/composed_pointer_with_data_ut.cc
+++ b/unit_tests/composed_pointer_with_data_ut.cc
@@ -38,7 +38,7 @@ int main()
       expect((x.data_ & type::pointer_mask) == 0);
       expect(x.ptr() == nullptr);
       }
-
+    small_vectors_clang_unsafe_buffer_usage_begin  // clang-18
       {
       double test[2];
       type x{&test[1]};
@@ -57,5 +57,6 @@ int main()
       expect(x.data() == some_enum::maybe);
       expect(x.ptr() == &test[0]);
       }
+    small_vectors_clang_unsafe_buffer_usage_end  // clang-18
   };
   }

--- a/unit_tests/stack_buffer_ut.cc
+++ b/unit_tests/stack_buffer_ut.cc
@@ -218,10 +218,12 @@ int main()
             pop_status popres{ip::pop(stack, index)};
             if(succeed_range_valid == popres)
               {
-              std::span indata{it_beg, it_end};
-              ranges::subrange refsubrange{
-                ranges::begin(refvalue), ranges::next(ranges::begin(refvalue), static_cast<ptrdiff_t>(indata.size()))
-              };
+              small_vectors_clang_unsafe_buffer_usage_begin  //
+                std::span indata{it_beg, it_end};
+              small_vectors_clang_unsafe_buffer_usage_end  //
+                ranges::subrange refsubrange{
+                  ranges::begin(refvalue), ranges::next(ranges::begin(refvalue), static_cast<ptrdiff_t>(indata.size()))
+                };
               auto match{ranges::equal(indata, refsubrange)};
               constexpr_test(match);
               if(!match)

--- a/unit_tests/static_vector_ut.cc
+++ b/unit_tests/static_vector_ut.cc
@@ -11,7 +11,7 @@
 
 //____________________________________________________________________________//
 
-namespace small_vectors::inline v3_0
+namespace small_vectors::inline v3_2
   {
 
 struct non_trivial_counter : public non_trivial
@@ -166,7 +166,7 @@ test_result consteval consteval_static_vector_deduced_types()
 
 static_assert(consteval_static_vector_deduced_types<int32_t>());
 static_assert(consteval_static_vector_deduced_types<aligned_3_byte_struct>());
-  }  // namespace small_vectors::inline v3_0
+  }  // namespace small_vectors::inline v3_2
 
 using namespace small_vectors;
 using boost::ut::operator""_test;

--- a/unit_tests/string_ut.cc
+++ b/unit_tests/string_ut.cc
@@ -62,7 +62,7 @@ using ut::operator""_test;
 using namespace ut::operators::terse;
 using metatests::test_result;
 
-namespace small_vectors::inline v3_0
+namespace small_vectors::inline v3_2
   {
 
 consteval bool verify_basic_string()
@@ -124,7 +124,7 @@ static constexpr auto test_buffer_view = test_buffer.null_terminated_buffor_view
 static_assert(test_buffer_view == std::string_view{"Test45"});
 
 static_assert(verify_basic_string());
-  }  // namespace small_vectors::inline v3_0
+  }  // namespace small_vectors::inline v3_2
 
 using namespace small_vectors;
 

--- a/unit_tests/unaligned_ut.cc
+++ b/unit_tests/unaligned_ut.cc
@@ -6,6 +6,7 @@
 using traits_list = metatests::type_list<uint8_t, std::byte>;
 using namespace metatests;
 
+small_vectors_clang_unsafe_buffer_usage_begin  //
 int main()
   {
   using namespace boost::ut;
@@ -94,3 +95,5 @@ int main()
     result |= run_consteval_test<traits_list>(fn_tmpl);
   };
   }
+
+small_vectors_clang_unsafe_buffer_usage_end  //

--- a/unit_tests/uninitialized_constexpr_ut.cc
+++ b/unit_tests/uninitialized_constexpr_ut.cc
@@ -195,8 +195,10 @@ int main()
       T * ptr{alloc.allocate(4)};
       small_vectors::detail::uninitialized_relocate_if_noexcept_n(source.begin(), 4u, ptr);
       expect(ctr == 8) << "expecting destructor was not called 8 times" << ctr;
-      expect(std::ranges::equal(std::span<T const>{source}, std::span<T const>{ptr, 4}));
-      alloc.deallocate(ptr, 4);
+      small_vectors_clang_unsafe_buffer_usage_begin  //
+        expect(std::ranges::equal(std::span<T const>{source}, std::span<T const>{ptr, 4}));
+      small_vectors_clang_unsafe_buffer_usage_end  //
+        alloc.deallocate(ptr, 4);
     };
     "movable"_test = [&]
     {
@@ -208,8 +210,10 @@ int main()
       small_vectors::detail::uninitialized_relocate_if_noexcept_n(source.begin(), 4u, ptr);
       // range in ptr is not destroyed
       expect(ctr == 4) << "expecting destructor was called 4 times by uninitialized_relocate_n" << ctr;
-      expect(std::ranges::equal(std::span{source}, std::span{ptr, 4}));
-      alloc.deallocate(ptr, 4);
+      small_vectors_clang_unsafe_buffer_usage_begin  //
+        expect(std::ranges::equal(std::span{source}, std::span{ptr, 4}));
+      small_vectors_clang_unsafe_buffer_usage_end  //
+        alloc.deallocate(ptr, 4);
     };
     "copyable"_test = [&]
     {
@@ -221,8 +225,10 @@ int main()
       small_vectors::detail::uninitialized_relocate_if_noexcept_n(source.begin(), 4u, ptr);
       // range in ptr is not destroyed
       expect(ctr == 4) << "expecting destructor was called 4 times by uninitialized_relocate_if_noexcept_n" << ctr;
-      expect(std::ranges::equal(std::span{source}, std::span{ptr, 4}));
-      alloc.deallocate(ptr, 4);
+      small_vectors_clang_unsafe_buffer_usage_begin  //
+        expect(std::ranges::equal(std::span{source}, std::span{ptr, 4}));
+      small_vectors_clang_unsafe_buffer_usage_end  //
+        alloc.deallocate(ptr, 4);
     };
   };
   }

--- a/unit_tests/ut_core/unit_test_core.h
+++ b/unit_tests/ut_core/unit_test_core.h
@@ -7,8 +7,10 @@
 #include <cassert>
 #include <source_location>
 #include <iostream>
-
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunsafe-buffer-usage"
 #include <boost_ut.h>
+#pragma clang diagnostic pop
 
 namespace metatests
   {

--- a/update_namespace.bash
+++ b/update_namespace.bash
@@ -2,12 +2,12 @@
 
 # Define the search and replace strings
 search_string="small_vectors::inline v3_0"
-replace_string="namespace small_vectors::inline v3_1"
+replace_string="small_vectors::inline v3_2"
 
 # Loop over files with specified extensions and perform the replacement
 find . -type f \( -name "*.h" -o -name "*.hpp" -o -name "*.cc" -o -name "*.cpp" \) -exec sed -i "s/$search_string/$replace_string/g" {} +
 
 search_string="small_vectors::v3_0"
-replace_string="namespace small_vectors::v3_1"
+replace_string="small_vectors::v3_2"
 
 echo "Replacement complete."


### PR DESCRIPTION
- error handling for some bufffer acceses
- cleanup unsafe-buffer-usage warnings to not pollute user code.