### PR TITLE
fix inclass storage, rename relocatable

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -60,8 +60,8 @@
       "inherits": ["clang-18-release", "cfg-libc++"]
     },
     {
-      "name": "clang-18-libc++release-asan",
-      "inherits": ["clang-18-release", "cfg-libc++"],
+      "name": "clang-19-libc++release-asan",
+      "inherits": ["clang-19-release", "cfg-libc++"],
       "cacheVariables": {
         "CMAKE_CXX_FLAGS": "-ggdb -fvisibility=default -fno-omit-frame-pointer -fsanitize=address -fsanitize-address-use-after-scope -fsanitize=undefined",
         "CMAKE_EXE_LINKER_FLAGS": "-fsanitize=address -fsanitize=undefined",
@@ -123,8 +123,8 @@
       "configurePreset": "clang-18-libc++release"
     },
     {
-      "name": "clang-18-libc++release-asan",
-      "configurePreset": "clang-18-libc++release-asan"
+      "name": "clang-19-libc++release-asan",
+      "configurePreset": "clang-19-libc++release-asan"
     },
     {
       "name": "clang-17-release",
@@ -170,8 +170,8 @@
       "execution": {"noTestsAction": "error", "stopOnFailure": true}
     },
     {
-      "name": "clang-18-libc++release-asan",
-      "configurePreset": "clang-18-libc++release-asan",
+      "name": "clang-19-libc++release-asan",
+      "configurePreset": "clang-19-libc++release-asan",
       "output": {"outputOnFailure": true},
       "execution": {"noTestsAction": "error", "stopOnFailure": true}
     },
@@ -270,19 +270,19 @@
       ]
     },
     {
-      "name": "clang-18-libc++release-asan",
+      "name": "clang-19-libc++release-asan",
       "steps": [
         {
           "type": "configure",
-          "name": "clang-18-libc++release-asan"
+          "name": "clang-19-libc++release-asan"
         },
         {
           "type": "build",
-          "name": "clang-18-libc++release-asan"
+          "name": "clang-19-libc++release-asan"
         },
         {
           "type": "test",
-          "name": "clang-18-libc++release-asan"
+          "name": "clang-19-libc++release-asan"
         }
       ]
     },

--- a/include/small_vectors/basic_string.h
+++ b/include/small_vectors/basic_string.h
@@ -619,7 +619,7 @@ struct basic_string_t
   };
 
 template<typename V, uint64_t N, typename T>
-consteval bool adl_decl_relocatable(basic_string_t<V, N, T> const *)
+consteval bool adl_decl_trivially_destructible_after_move(basic_string_t<V, N, T> const *)
   {
   return true;
   }

--- a/include/small_vectors/concepts/concepts.h
+++ b/include/small_vectors/concepts/concepts.h
@@ -66,13 +66,14 @@ inline constexpr bool is_nothrow_copy_constr_and_constr_v
 
 ///\brief explicit declared relocation capable
 template<typename T>
-concept explicit_relocatable = requires(T const * value) {
-  { adl_decl_relocatable(value) } -> std::same_as<bool>;
-  requires adl_decl_relocatable(static_cast<T const *>(nullptr));
+concept explicit_trivially_destructible_after_move = requires(T const * value) {
+  { adl_decl_trivially_destructible_after_move(value) } -> std::same_as<bool>;
+  requires adl_decl_trivially_destructible_after_move(static_cast<T const *>(nullptr));
 };
 
 template<typename T>
-concept relocatable = explicit_relocatable<T> || std::is_trivially_destructible_v<T>;
+concept trivially_destructible_after_move
+  = explicit_trivially_destructible_after_move<T> || std::is_trivially_destructible_v<T>;
 
 template<typename T, typename... Args>
 concept same_as_any_of = std::disjunction_v<std::is_same<T, Args>...>;

--- a/include/small_vectors/detail/uninitialized_constexpr.h
+++ b/include/small_vectors/detail/uninitialized_constexpr.h
@@ -8,12 +8,6 @@
 
 namespace small_vectors::inline v3_2::detail
   {
-// By default, only trivially copyable or trivially movable types are relocatable
-// however, is_relocatable may be specialized to mark complex types as relocatable
-// TODO
-template<typename V>
-inline constexpr bool is_relocatable_v = std::is_trivially_copyable_v<V>;
-
 template<typename iterator_type>
 using iterator_value_type_t = std::iter_value_t<iterator_type>;
 
@@ -90,8 +84,8 @@ struct range_unwinder
   };
 
 template<typename value_type>
-constexpr void uninitialized_default_construct(value_type * store
-) noexcept(std::is_nothrow_default_constructible_v<value_type>)
+constexpr void
+  uninitialized_default_construct(value_type * store) noexcept(std::is_nothrow_default_constructible_v<value_type>)
   {
   if(std::is_constant_evaluated())
     std::construct_at(store);
@@ -100,8 +94,8 @@ constexpr void uninitialized_default_construct(value_type * store
   }
 
 template<typename value_type>
-constexpr void uninitialized_value_construct(value_type * store
-) noexcept(std::is_nothrow_default_constructible_v<value_type>)
+constexpr void
+  uninitialized_value_construct(value_type * store) noexcept(std::is_nothrow_default_constructible_v<value_type>)
   {
   std::construct_at(store);
   }
@@ -201,10 +195,10 @@ inline auto uninitialized_copy_n_impl(InputIterator first, Size count, OutputIte
 template<concepts::input_iterator InputIterator, std::integral Size, concepts::forward_iterator ForwardIterator>
 inline auto uninitialized_copy_n_impl(InputIterator first, Size count, ForwardIterator result)
   {
-  static_assert(
-    !(contiguous_iterator_with_trivialy_copy_constructible<InputIterator>
-      && contiguous_iterator_with_trivialy_copy_constructible<ForwardIterator>)
-  );
+  static_assert(!(
+    contiguous_iterator_with_trivialy_copy_constructible<InputIterator>
+    && contiguous_iterator_with_trivialy_copy_constructible<ForwardIterator>
+  ));
   constexpr bool use_nothrow = std::is_nothrow_constructible_v<iterator_value_type_t<InputIterator>>;
   using unwind = range_unwinder<use_nothrow, ForwardIterator>;
   unwind cur{result};
@@ -227,10 +221,10 @@ inline auto uninitialized_copy_impl(InputIterator first, InputIterator last, Out
 template<concepts::input_iterator InputIterator, concepts::forward_iterator ForwardIterator>
 inline auto uninitialized_copy_impl(InputIterator first, InputIterator last, ForwardIterator result)
   {
-  static_assert(
-    !(contiguous_iterator_with_trivialy_copy_constructible<InputIterator>
-      && contiguous_iterator_with_trivialy_copy_constructible<ForwardIterator>)
-  );
+  static_assert(!(
+    contiguous_iterator_with_trivialy_copy_constructible<InputIterator>
+    && contiguous_iterator_with_trivialy_copy_constructible<ForwardIterator>
+  ));
   constexpr bool use_nothrow = std::is_nothrow_constructible_v<iterator_value_type_t<InputIterator>>;
   using unwind = range_unwinder<use_nothrow, ForwardIterator>;
   unwind cur{result};
@@ -291,10 +285,10 @@ inline auto uninitialized_move_impl(InputIterator first, InputIterator last, Out
 template<concepts::input_iterator InputIterator, concepts::forward_iterator ForwardIterator>
 inline auto uninitialized_move_impl(InputIterator first, InputIterator last, ForwardIterator result)
   {
-  static_assert(
-    !(contiguous_iterator_with_trivialy_move_constructible<InputIterator>
-      && contiguous_iterator_with_trivialy_move_constructible<ForwardIterator>)
-  );
+  static_assert(!(
+    contiguous_iterator_with_trivialy_move_constructible<InputIterator>
+    && contiguous_iterator_with_trivialy_move_constructible<ForwardIterator>
+  ));
   constexpr bool use_nothrow = std::is_nothrow_constructible_v<iterator_value_type_t<InputIterator>>;
   using unwind = range_unwinder<use_nothrow, ForwardIterator>;
   unwind cur{result};
@@ -317,10 +311,10 @@ inline auto uninitialized_move_n_impl(InputIterator first, Size count, OutputIte
 template<concepts::input_iterator InputIterator, std::integral Size, concepts::forward_iterator ForwardIterator>
 auto uninitialized_move_n_impl(InputIterator first, Size count, ForwardIterator result)
   {
-  static_assert(
-    !(contiguous_iterator_with_trivialy_move_constructible<InputIterator>
-      && contiguous_iterator_with_trivialy_move_constructible<ForwardIterator>)
-  );
+  static_assert(!(
+    contiguous_iterator_with_trivialy_move_constructible<InputIterator>
+    && contiguous_iterator_with_trivialy_move_constructible<ForwardIterator>
+  ));
   constexpr bool use_nothrow = std::is_nothrow_constructible_v<iterator_value_type_t<InputIterator>>;
   using unwind = range_unwinder<use_nothrow, ForwardIterator>;
   unwind cur{result};
@@ -402,7 +396,7 @@ inline constexpr void uninitialized_relocate_n(InputIterator first, size_type co
   {
   using value_type = iterator_value_type_t<InputIterator>;
   uninitialized_move_n(first, count, result);
-  if constexpr(!concepts::relocatable<value_type>)
+  if constexpr(!concepts::trivially_destructible_after_move<value_type>)
     destroy_range(first, size_type(0u), count);
   }
 

--- a/include/small_vectors/relocatable/std/deque.h
+++ b/include/small_vectors/relocatable/std/deque.h
@@ -5,7 +5,7 @@
 namespace std
   {
 template<typename Tp, typename Alloc>
-consteval bool adl_decl_relocatable(deque<Tp, Alloc> const *)
+consteval bool adl_decl_trivially_destructible_after_move(deque<Tp, Alloc> const *)
   {
   return true;
   }

--- a/include/small_vectors/relocatable/std/map.h
+++ b/include/small_vectors/relocatable/std/map.h
@@ -5,7 +5,7 @@
 namespace std
   {
 template<typename Key, typename Tp, typename Compare, typename Alloc>
-consteval bool adl_decl_relocatable(map<Key, Tp, Compare, Alloc> const *)
+consteval bool adl_decl_trivially_destructible_after_move(map<Key, Tp, Compare, Alloc> const *)
   {
   return true;
   }

--- a/include/small_vectors/relocatable/std/set.h
+++ b/include/small_vectors/relocatable/std/set.h
@@ -5,7 +5,7 @@
 namespace std
   {
 template<typename Key, typename Compare, typename Alloc>
-consteval bool adl_decl_relocatable(set<Key, Compare, Alloc> const *)
+consteval bool adl_decl_trivially_destructible_after_move(set<Key, Compare, Alloc> const *)
   {
   return true;
   }

--- a/include/small_vectors/relocatable/std/unordered_map.h
+++ b/include/small_vectors/relocatable/std/unordered_map.h
@@ -5,7 +5,7 @@
 namespace std
   {
 template<typename Key, typename Tp, typename Hash, typename Pred, typename Alloc>
-consteval bool adl_decl_relocatable(unordered_map<Key, Tp, Hash, Pred, Alloc> const *)
+consteval bool adl_decl_trivially_destructible_after_move(unordered_map<Key, Tp, Hash, Pred, Alloc> const *)
   {
   return true;
   }

--- a/include/small_vectors/relocatable/std/unordered_set.h
+++ b/include/small_vectors/relocatable/std/unordered_set.h
@@ -5,7 +5,7 @@
 namespace std
   {
 template<typename Tp, typename Hash, typename Pred, typename Alloc>
-consteval bool adl_decl_relocatable(unordered_set<Tp, Hash, Pred, Alloc> const *)
+consteval bool adl_decl_trivially_destructible_after_move(unordered_set<Tp, Hash, Pred, Alloc> const *)
   {
   return true;
   }

--- a/include/small_vectors/relocatable/std/vector.h
+++ b/include/small_vectors/relocatable/std/vector.h
@@ -5,7 +5,7 @@
 namespace std
   {
 template<typename Tp, typename Alloc>
-consteval bool adl_decl_relocatable(vector<Tp, Alloc> const *)
+consteval bool adl_decl_trivially_destructible_after_move(vector<Tp, Alloc> const *)
   {
   return true;
   }

--- a/include/small_vectors/small_vector.h
+++ b/include/small_vectors/small_vector.h
@@ -164,8 +164,9 @@ struct small_vector
 
   ///\warning copy assignment may throw always, for dynamic as there is no other way to signalize allocation error
   template<uint64_t M>
-  constexpr auto assign(small_vector<value_type, size_type, M> const & rh
-  ) noexcept(std::is_nothrow_copy_assignable_v<value_type>) -> small_vector &
+  constexpr auto
+    assign(small_vector<value_type, size_type, M> const & rh) noexcept(std::is_nothrow_copy_assignable_v<value_type>)
+      -> small_vector &
     {
     storage_.assign_copy(rh.storage_);
     return *this;
@@ -361,7 +362,7 @@ struct small_vector
 
 // always relocatable after move
 template<typename V, std::unsigned_integral S, uint64_t N>
-consteval bool adl_decl_relocatable(small_vector<V, S, N> const *)
+consteval bool adl_decl_trivially_destructible_after_move(small_vector<V, S, N> const *)
   {
   return true;
   }

--- a/include/small_vectors/static_vector.h
+++ b/include/small_vectors/static_vector.h
@@ -108,7 +108,8 @@ struct static_vector
 
   template<uint64_t M>
     requires(M < N && std::copy_constructible<value_type>)
-  explicit constexpr static_vector(static_vector<value_type, M> const & rh
+  explicit constexpr static_vector(
+    static_vector<value_type, M> const & rh
   ) noexcept(std::is_nothrow_copy_constructible_v<value_type>)
     {
     storage_.construct_copy(rh.storage_);
@@ -200,8 +201,9 @@ struct static_vector
     }
 
   template<vector_tune_e tune = vector_tune_e::checked, typename... Args>
-  inline constexpr auto emplace_back(Args &&... args
-  ) noexcept(tune == vector_tune_e::unchecked || noexcept(detail::emplace_back(*this, std::forward<Args>(args)...)))
+  inline constexpr auto emplace_back(Args &&... args) noexcept(
+    tune == vector_tune_e::unchecked || noexcept(detail::emplace_back(*this, std::forward<Args>(args)...))
+  )
     {
     if constexpr(tune == vector_tune_e::checked)
       return detail::emplace_back(*this, std::forward<Args>(args)...);
@@ -275,7 +277,7 @@ struct static_vector
 
 // always relocatable after move
 template<concepts::vector_constraints V, uint64_t N>
-consteval bool adl_decl_relocatable(static_vector<V, N> const *)
+consteval bool adl_decl_trivially_destructible_after_move(static_vector<V, N> const *)
   {
   return true;
   }

--- a/include/small_vectors/version.h
+++ b/include/small_vectors/version.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#define SMALL_VECTORS_VERSION "3.2.1"
+#define SMALL_VECTORS_VERSION "3.3.0"
 
 #ifdef __clang__
 #define small_vectors_clang_do_pragma(x) _Pragma(#x)

--- a/unit_tests/uninitialized_constexpr_ut.cc
+++ b/unit_tests/uninitialized_constexpr_ut.cc
@@ -69,7 +69,7 @@ inline bool operator==(explicit_relocatable_t const & lh, explicit_relocatable_t
   return lh.i_ == rh.i_;
   }
 
-consteval bool adl_decl_relocatable(explicit_relocatable_t const *) { return true; }
+consteval bool adl_decl_trivially_destructible_after_move(explicit_relocatable_t const *) { return true; }
 
 struct implicit_relocatable_t
   {
@@ -155,11 +155,11 @@ static_assert(!std::is_trivially_destructible_v<explicit_relocatable_t>);
 static_assert(!std::is_trivially_destructible_v<non_relocatable_t>);
 static_assert(!std::is_trivially_destructible_v<copy_non_relocatable_t>);
 
-static_assert(small_vectors::concepts::relocatable<explicit_relocatable_t>);
-static_assert(small_vectors::concepts::relocatable<implicit_relocatable_t>);
-static_assert(small_vectors::concepts::relocatable<int>);
-static_assert(!small_vectors::concepts::relocatable<non_relocatable_t>);
-static_assert(!small_vectors::concepts::relocatable<copy_non_relocatable_t>);
+static_assert(small_vectors::concepts::trivially_destructible_after_move<explicit_relocatable_t>);
+static_assert(small_vectors::concepts::trivially_destructible_after_move<implicit_relocatable_t>);
+static_assert(small_vectors::concepts::trivially_destructible_after_move<int>);
+static_assert(!small_vectors::concepts::trivially_destructible_after_move<non_relocatable_t>);
+static_assert(!small_vectors::concepts::trivially_destructible_after_move<copy_non_relocatable_t>);
 
 int main()
   {


### PR DESCRIPTION
- fix inclass storage destroy is_trivially_destructible_v check
- update inclass trivially copy/move to use memcpy
- rename relocatable to trivially_destructible_after_move